### PR TITLE
Adds the option of randomization for robot arm positions

### DIFF
--- a/robocasa/demos/demo_kitchen_scenes.py
+++ b/robocasa/demos/demo_kitchen_scenes.py
@@ -101,7 +101,7 @@ if __name__ == "__main__":
         use_camera_obs=False,
         control_freq=20,
         renderer=args.renderer,
-        robot_randomness_radius=0.5, # suggested to use a number within [0.5, 2.0]; otherwise it may be illegal due to cabinet collision
+        robot_randomness_radius=None, # suggested to use a number within [0.5, 2.0]; otherwise it may be illegal due to cabinet collision
     )
 
     # Grab reference to controller config and convert it to json-encoded string

--- a/robocasa/demos/demo_kitchen_scenes.py
+++ b/robocasa/demos/demo_kitchen_scenes.py
@@ -101,6 +101,7 @@ if __name__ == "__main__":
         use_camera_obs=False,
         control_freq=20,
         renderer=args.renderer,
+        robot_randomness_radius=0.5, # suggested to use a number within [0.5, 2.0]; otherwise it may be illegal due to cabinet collision
     )
 
     # Grab reference to controller config and convert it to json-encoded string

--- a/robocasa/models/objects/fixtures/fixture.py
+++ b/robocasa/models/objects/fixtures/fixture.py
@@ -322,11 +322,14 @@ class Fixture(MujocoXMLObject):
         
         return sites
     
+    # Return an empty list when get_ext_sites is not initialized well.
     def get_bbox_points(self, trans=None, rot=None):
         """
         Get the full set of bounding box points of the object
         rot: a rotation matrix
         """
+        if len(self._bounds_sites) == 0:
+            return []
         bbox_offsets = self.get_ext_sites(all_points=True, relative=True)
 
         if trans is None:


### PR DESCRIPTION
1. Adds the parameter of `robot_randomness_radius` for robot pos sampling range. The robot ori will be uniformly sampled in all degrees.
2. Adds an intersect check `robot_intersects_with_obj` for a `RobotModel` and `MJCFObject`/`Fixture`.
3. Improvements:
3.1 Using a radius will not allow the robot arm to 3d-overlap with an open cabinet, not as good as using mesh.
3.2 `robocasa.models.objects.fixtures.cabinets.PanelCabinet` doesn't have bbox set up properly, even if it's a `Fixture`.
3.3 There are fixtures like `robocasa.models.objects.fixtures.others.Box/Wall`, which are objects without bbox supported.
4. See successful examples below:
![Pasted image (2)](https://github.com/robocasa/robocasa/assets/13745709/74168367-b82f-41d9-80ad-5a8717494fbb)
![Pasted image (3)](https://github.com/robocasa/robocasa/assets/13745709/5152dec7-ce5c-4319-b30d-740b4446a406)
![Pasted image (4)](https://github.com/robocasa/robocasa/assets/13745709/078f3fc0-9914-4a05-a433-985203f4d5b5)
![Pasted image (5)](https://github.com/robocasa/robocasa/assets/13745709/e5773c5b-beb2-4616-8d6e-a24b3e13e7b6)
![Pasted image (6)](https://github.com/robocasa/robocasa/assets/13745709/f9f208e7-6304-4146-96a5-2e29abd8755f)

5. This setup can be invalid if we use a 3d-bbox collision check:
![Screenshot from 2024-05-30 01-50-56](https://github.com/robocasa/robocasa/assets/13745709/c72bd779-d4d8-4d0b-805c-a0132aff6c9a)
