### PR TITLE
Specify robosuite version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ RoboCasa works across all major computing platforms. The easiest way to set up i
 
    ```sh
    git clone https://github.com/ARISE-Initiative/robosuite v1.5.1
-   cd robosuite
+   cd v1.5.1
    pip install -e .
    ```
 4. Clone and setup this repo:


### PR DESCRIPTION
Newer version of Robosuite not compatible with Robocasa Python scripts