### PR TITLE
Forward camera_depths from create_env and add depth to Gym observation space

### DIFF
--- a/robocasa/utils/env_utils.py
+++ b/robocasa/utils/env_utils.py
@@ -103,6 +103,14 @@ def create_env(
     else:
         raise ValueError('split must be either {None, "all", "pretrain", "target"}')
 
+    # Remove "camera_depths" from kwargs to avoid conflict with already defined
+    # camera_depths in env_kwargs. Alternatively, remove camera_depths from env_kwargs.
+    if "camera_depths" in kwargs:
+        camera_depths = kwargs["camera_depths"]
+        del kwargs["camera_depths"]
+    else:
+        camera_depths = False
+
     env_kwargs = dict(
         env_name=env_name,
         robots=robots,
@@ -115,7 +123,7 @@ def create_env(
         ignore_done=True,
         use_object_obs=True,
         use_camera_obs=(not render_onscreen),
-        camera_depths=False,
+        camera_depths=camera_depths,
         seed=seed,
         obj_instance_split=obj_instance_split,
         generative_textures=generative_textures,

--- a/robocasa/wrappers/gym_wrapper.py
+++ b/robocasa/wrappers/gym_wrapper.py
@@ -227,13 +227,20 @@ class RoboCasaGymEnv(gym.Env):
         # now remap observation and action space
         self.observation_space = self.key_converter.deduce_observation_space(self.env)
         mapped_names, _, _, _ = self.key_converter.get_camera_config()
-        for mapped_name in mapped_names:
+        for mapped_name, cam_depth in zip(mapped_names, self.env.camera_depths):
             self.observation_space[mapped_name] = spaces.Box(
                 low=0,
                 high=255,
                 shape=(self.camera_heights, self.camera_widths, 3),
                 dtype=np.uint8,
             )
+            if cam_depth:
+                self.observation_space[f"{mapped_name}_depth"] = spaces.Box(
+                    low=-np.inf,
+                    high=np.inf,
+                    shape=(self.camera_heights, self.camera_widths, 1),
+                    dtype=np.float32,
+                )
 
         self.observation_space["annotation.human.task_description"] = spaces.Text(
             max_length=256, charset=ALLOWED_LANGUAGE_CHARSET
@@ -249,6 +256,8 @@ class RoboCasaGymEnv(gym.Env):
             if obs_name.endswith("_image"):
                 # image observations
                 raw_obs[obs_name] = process_img(obs_value)
+            elif obs_name.endswith("_depth"):
+                raw_obs[obs_name] = process_img(obs_value).astype(np.float32)
             else:
                 # non-image observations
                 raw_obs[obs_name] = obs_value.astype(np.float32)
@@ -259,6 +268,11 @@ class RoboCasaGymEnv(gym.Env):
                 raw_obs[f"{name}_image"] = np.zeros(
                     (self.camera_heights, self.camera_widths, 3), dtype=np.uint8
                 )
+            for name, cam_depth in zip(self.camera_names, self.env.camera_depths):
+                if cam_depth:
+                    raw_obs[f"{name}_depth"] = np.zeros(
+                        (self.camera_heights, self.camera_widths, 1), dtype=np.float32
+                    )
 
         self.render_cache = raw_obs[self.render_obs_key]
         raw_obs["language"] = self.env.get_ep_meta().get("lang", "")
@@ -277,6 +291,8 @@ class RoboCasaGymEnv(gym.Env):
         mapped_names, camera_names, _, _ = self.key_converter.get_camera_config()
         for mapped_name, camera_name in zip(mapped_names, camera_names):
             obs[mapped_name] = basic_obs[camera_name + "_image"]
+            if f"{camera_name}_depth" in basic_obs:
+                obs[f"{mapped_name}_depth"] = basic_obs[f"{camera_name}_depth"]
             # self.process_img(
             #     basic_obs[camera_name + "_image"]
             # )

--- a/robocasa/wrappers/gym_wrapper.py
+++ b/robocasa/wrappers/gym_wrapper.py
@@ -21,9 +21,9 @@ class PandaOmronKeyConverter:
     @classmethod
     def get_camera_config(cls):
         mapped_names = [
-            "video.robot0_agentview_left",
-            "video.robot0_agentview_right",
-            "video.robot0_eye_in_hand",
+            "robot0_agentview_left",
+            "robot0_agentview_right",
+            "robot0_eye_in_hand",
         ]
         camera_names = [
             "robot0_agentview_left",
@@ -290,7 +290,7 @@ class RoboCasaGymEnv(gym.Env):
                 raise ValueError(f"Unknown key: {k}")
         mapped_names, camera_names, _, _ = self.key_converter.get_camera_config()
         for mapped_name, camera_name in zip(mapped_names, camera_names):
-            obs[mapped_name] = basic_obs[camera_name + "_image"]
+            obs[f"{mapped_name}_image"] = basic_obs[camera_name + "_image"]
             if f"{camera_name}_depth" in basic_obs:
                 obs[f"{mapped_name}_depth"] = basic_obs[f"{camera_name}_depth"]
             # self.process_img(


### PR DESCRIPTION
## Summary

1. When `camera_depths` arg was passed to gym.make it conflicted with an existing key in `env_kwargs` in `create_env`. Updated the code to use the passed in as an argument if available, and then delete the key to avoid the exception from conflicting keys. Alternatively, we can just remove the key in `env_kwargs` since it's already the default value expected by robosuite.make.
2. Even if depth was enabled, callers never saw depth values because only rgb values were returned and there was no check to see if depth was requested. Updated to return depth as well.
4. Add _depth to observation space if depth is enabled.

## Changes

### `robocasa/utils/env_utils.py`

- Read `camera_depths` from `kwargs` when present, **remove it from `kwargs`** before the `**kwargs` merge into `env_kwargs`.

### `robocasa/wrappers/gym_wrapper.py`

- **`get_observation`**: forward `robot0_*_depth` (when present) to the mapped `video.*_depth` keys.
- **`_create_obs_and_action_space`**: for each camera, if `self.env.camera_depths[i]`, register a **`Box(H, W, 1, float32)`** for `{mapped_name}_depth` immediately after its RGB entry (same order as observations).
- **`get_basic_observation`**: apply the **same vertical flip** to `*_depth` as for `*_image`; when **`enable_render` is `False`**, zero **depth** for depth-enabled cameras as well as blacking out RGB (stable shapes and keys).