### PR TITLE
Include data files in built wheels via MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include robocasa *.yaml *.xml *.json *.png *.obj *.csv *.urdf *.stl *.mtl


### PR DESCRIPTION
setup.py already sets include_package_data=True, but without a MANIFEST.in the sdist/wheel builds drop all non-Python files under robocasa/ (assets/, models/, scenes/, etc.). Non-editable installs end up missing the JSON/XML/YAML asset descriptors and the kitchen asset downloader fails at first run:

```
  FileNotFoundError: ...
    site-packages/robocasa/models/assets/box_links/box_links_assets.json
```

This is invisible with `pip install -e .` because the editable install uses the source tree directly, but breaks any consumer that wants to install from a git source or built wheel.

One-line MANIFEST.in fix that recursively includes the file types actually present under robocasa/ (.yaml, .xml, .json, .png, .obj, .csv, plus .urdf/.stl/.mtl for forward-compat as more assets land). After this change, building the wheel with `uv build --wheel` includes box_links_assets.json and the other ~210 data files; non-editable installs work without any other change.