### PR TITLE
Improve SONIC G1 VLA collection and task compatibility

### DIFF
--- a/docs/SONIC_VLA_STREAMING.md
+++ b/docs/SONIC_VLA_STREAMING.md
@@ -7,13 +7,25 @@ SONIC controller remains unchanged.
 
 ## What it publishes
 
-Running `robocasa/scripts/collect_sonic_demos.py --vla-stream` adds three VLA
+Running `robocasa/scripts/collect_sonic_demos.py --vla-stream` adds four VLA
 integration pieces:
 
 - A camera stream on port `5555` using SONIC's `ImageMessageSchema`.
 - A subscriber for VR/PICO `manager_state` toggles on port `5556`.
 - A keyboard publisher on port `5580` so local collector hotkeys can keep
   `run_data_exporter.py` in sync.
+- A state-style metadata publisher on port `5581` that forwards the exact
+  instruction sampled for the current RoboCasa episode.
+
+The instruction is captured once after each successful reset. A `ready` state
+is repeated on port `5581`; pressing record changes it to a versioned `start`
+attempt carrying the same episode ID and instruction. The exporter waits for
+that start metadata before entering `RECORDING`, then locks the text before the
+episode's first frame.
+For object-dependent tasks such as `LoadDishwasher`, a generated instruction
+like `Pick up the cup and bowl ...` therefore becomes the LeRobot task label
+automatically. `--task-prompt` remains a fallback for an older collector, a
+missing/blank task instruction, or non-RoboCasa collection.
 
 Default camera settings match the real VLA path: `robot0_head_camera` is
 published as `ego_view` at `640x480`, `30 Hz`, with the MuJoCo image vertically
@@ -83,13 +95,25 @@ The PICO manager publishes VR pose/planner inputs and `manager_state` recording
 toggles on port `5556`. Keep this process running for both teleop control and
 episode start/save/discard events.
 
+Each streamed `pose` message remains a complete sliding window of five PICO
+frames. SONIC merges that window by `frame_index`; latest-only transport means
+the newest complete window, not a one-frame pose. The exporter uses independent
+latest-only subscribers for `pose`, `planner`, and `manager_state`, so those
+topics cannot replace one another in a shared conflated queue.
+
+`manager_state` repeats a manager session ID, monotonic event counters, and the
+last event timestamps. This allows the collector and exporter to discard stale
+continuous state after a long save/reset while still observing a one-frame
+start/save/discard button edge. These fields affect recording lifecycle only;
+they are not part of SONIC's policy observation.
+
 ### 4. Start the VLA exporter
 
 ```bash
 cd /home/amaddukuri/Projects/GR00T-WholeBodyControl
 source .venv_data_collection/bin/activate
 python gear_sonic/scripts/run_data_exporter.py \
-  --task-prompt "<task prompt>" \
+  --task-prompt "<fallback task prompt>" \
   --dataset-name <dataset_name> \
   --root-output-dir /tmp/sonic_vla_exports \
   --no-text-to-speech
@@ -97,7 +121,17 @@ python gear_sonic/scripts/run_data_exporter.py \
 
 The exporter consumes the RoboCasa `ego_view` camera stream on port `5555`, the
 VR/PICO stream on port `5556`, SONIC state/config streams from the controller
-on port `5557`, and keyboard sync on port `5580`.
+on port `5557`, keyboard sync on port `5580`, and RoboCasa episode instructions
+on port `5581`.
+
+Before recording, confirm that the exporter prints both lines below. The second
+line is the task text that will be written to each frame in that episode:
+
+```text
+[EpisodeInstruction] ready: <session:sequence> attempt=0 -> <sampled instruction>
+[EpisodeInstruction] start matched: <session:sequence> attempt=1 -> <sampled instruction>
+[EpisodeInstruction] recording task from RoboCasa <session:sequence>: <sampled instruction>
+```
 
 Common overrides:
 
@@ -109,7 +143,15 @@ Common overrides:
 --vla-camera-hz 30
 --no-vla-camera-flip
 --no-vla-keyboard-sync
+--vla-instruction-port 5581
+--no-vla-instruction-sync
 ```
+
+Exporter-side overrides are `--instruction-zmq-host`,
+`--instruction-zmq-port`, `--instruction-wait-timeout`, and
+`--no-sync-robocasa-instruction`. Use the last option with an older RoboCasa
+collector that does not publish port `5581`; the existing `--task-prompt` is
+then used immediately.
 
 ## Episode controls
 
@@ -124,6 +166,12 @@ VR/PICO `manager_state` toggles are also consumed:
 
 - `toggle_data_collection`: start when idle, save when recording.
 - `toggle_data_abort`: discard the current episode.
+
+After `k` or `x`, `[sonic-timing]` lines split the transition into finalize,
+environment reset, and source/instruction phases. The collection clock is
+resynchronized when the new episode is ready, so the 200 Hz loop does not try
+to catch up wall-clock deadlines that expired during a hard reset. Camera
+publication remains `640x480` at `30 Hz`.
 
 ## Real-time check
 

--- a/docs/SONIC_VLA_STREAMING.md
+++ b/docs/SONIC_VLA_STREAMING.md
@@ -58,7 +58,7 @@ cd /home/amaddukuri/Projects/robocasa-dev-sonic-vla
 /home/amaddukuri/Projects/GR00T-WholeBodyControl/.venv_sim/bin/python \
   robocasa/scripts/collect_sonic_demos.py \
   --environment Kitchen \
-  --layout 1 \
+  --layout -1 \
   --robot SonicG1 \
   --out /tmp/sonic_robocasa_demos \
   --vla-stream

--- a/docs/composite_tasks/task_attributes.json
+++ b/docs/composite_tasks/task_attributes.json
@@ -1597,11 +1597,11 @@
       "description": "Take the fruits from the plate on the dining counter and place two fruits in each bowl."
     },
     {
-      "name": "PortionHotDogs",
+      "name": "PortionPeaches",
       "activity": "Portioning Meals",
       "num_subtasks": 4,
       "moma_required": "Yes",
-      "description": "Place one bun and one sausage from the bowl on each plate."
+      "description": "Place one peach from the bowl on each plate."
     },
     {
       "name": "PortionInTupperware",

--- a/docs/tasks/_generated/composite_tasks_details.md
+++ b/docs/tasks/_generated/composite_tasks_details.md
@@ -1188,8 +1188,8 @@
           <td>Take the fruits from the plate on the dining counter and place two fruits in each bowl.</td>
         </tr>
         <tr>
-          <td><code>PortionHotDogs</code></td>
-          <td>Place one bun and one sausage from the bowl on each plate.</td>
+          <td><code>PortionPeaches</code></td>
+          <td>Place one peach from the bowl on each plate.</td>
         </tr>
         <tr>
           <td><code>PortionInTupperware</code></td>

--- a/robocasa/__init__.py
+++ b/robocasa/__init__.py
@@ -436,8 +436,8 @@ from robocasa.environments.kitchen.composite.portioning_meals.distribute_chicken
 from robocasa.environments.kitchen.composite.portioning_meals.portion_fruit_bowl import (
     PortionFruitBowl,
 )
-from robocasa.environments.kitchen.composite.portioning_meals.portion_hot_dogs import (
-    PortionHotDogs,
+from robocasa.environments.kitchen.composite.portioning_meals.portion_peaches import (
+    PortionPeaches,
 )
 from robocasa.environments.kitchen.composite.portioning_meals.portion_in_tupperware import (
     PortionInTupperware,
@@ -769,6 +769,9 @@ from robocasa.environments.kitchen.composite.storing_leftovers.store_leftovers_i
 )
 from robocasa.environments.kitchen.composite.tidying_cabinets_and_drawers.drawer_utensil_sort import (
     DrawerUtensilSort,
+)
+from robocasa.environments.kitchen.composite.tidying_cabinets_and_drawers.drawer_cake_sort import (
+    DrawerCakeSort,
 )
 from robocasa.environments.kitchen.composite.tidying_cabinets_and_drawers.organize_cleaning_supplies import (
     OrganizeCleaningSupplies,

--- a/robocasa/environments/kitchen/atomic/kitchen_doors.py
+++ b/robocasa/environments/kitchen/atomic/kitchen_doors.py
@@ -142,7 +142,8 @@ class ManipulateLowerDoor(ManipulateDoor):
 
     def _load_model(self, *args, **kwargs):
         super()._load_model(*args, **kwargs)
-        self._place_robot()
+        if self._place_robot():
+            self._write_robot_base_pose_to_model()
 
     def _place_robot(self):
         x_ofs = (self.fxtr.width / 2) + self.X_OFS

--- a/robocasa/environments/kitchen/atomic/kitchen_pick_place.py
+++ b/robocasa/environments/kitchen/atomic/kitchen_pick_place.py
@@ -864,6 +864,24 @@ class PickPlaceCounterToStove(PickPlace):
             )
         )
 
+        obj_placement = dict(
+            fixture=self.counter,
+            sample_region_kwargs=dict(ref=self.stove),
+            size=(0.30, 0.30),
+            pos=("ref", -1.0),
+            try_to_place_in="container",
+        )
+        if EnvUtils.is_sonic_g1(self):
+            obj_placement["try_to_place_in_kwargs"] = {
+                "placement": {
+                    "fixture": self.counter,
+                    "sample_region_kwargs": {"ref": self.stove},
+                    "size": (0.30, 0.30),
+                    "pos": ("ref", -1.0),
+                    "side": "front",
+                }
+            }
+
         cfgs.append(
             dict(
                 name="obj",
@@ -871,15 +889,7 @@ class PickPlaceCounterToStove(PickPlace):
                 exclude_obj_groups=self.exclude_obj_groups,
                 graspable=True,
                 cookable=True,
-                placement=dict(
-                    fixture=self.counter,
-                    sample_region_kwargs=dict(
-                        ref=self.stove,
-                    ),
-                    size=(0.30, 0.30),
-                    pos=("ref", -1.0),
-                    try_to_place_in="container",
-                ),
+                placement=obj_placement,
             )
         )
 

--- a/robocasa/environments/kitchen/composite/boiling/boil_corn.py
+++ b/robocasa/environments/kitchen/composite/boiling/boil_corn.py
@@ -13,6 +13,11 @@ class BoilCorn(Kitchen):
         2. Place the lid on the saucepan to start boiling
     """
 
+    # Keep the semantic requirements (contact, selected burner, burner on),
+    # while tolerating small shifts caused by placing the corn and lid.
+    SAUCEPAN_BURNER_THRESHOLD = 0.15
+    LID_ON_SAUCEPAN_THRESHOLD = 0.05
+
     def __init__(self, stove_id=FixtureType.STOVE, *args, **kwargs):
         self.stove_id = stove_id
         super().__init__(*args, **kwargs)
@@ -116,14 +121,21 @@ class BoilCorn(Kitchen):
         return cfgs
 
     def _check_success(self):
-        saucepan_loc = self.stove.check_obj_location_on_stove(self, "saucepan")
+        saucepan_loc = self.stove.check_obj_location_on_stove(
+            self,
+            "saucepan",
+            threshold=self.SAUCEPAN_BURNER_THRESHOLD,
+        )
         saucepan_on_burner = saucepan_loc == self.knob
 
         corn1_in_pot = OU.check_obj_in_receptacle(self, "corn1", "saucepan")
         corn2_in_pot = OU.check_obj_in_receptacle(self, "corn2", "saucepan")
 
         lid_on_saucepan = OU.check_obj_in_receptacle(
-            self, "saucepan_auxiliary", "saucepan", th=0.02
+            self,
+            "saucepan_auxiliary",
+            "saucepan",
+            th=self.LID_ON_SAUCEPAN_THRESHOLD,
         )
 
         gripper_far = OU.gripper_obj_far(self, obj_name="saucepan_auxiliary")

--- a/robocasa/environments/kitchen/composite/defrosting_food/move_to_counter.py
+++ b/robocasa/environments/kitchen/composite/defrosting_food/move_to_counter.py
@@ -46,6 +46,7 @@ class MoveToCounter(Kitchen):
                 graspable=True,
                 placement=dict(
                     fixture=self.fridge,
+                    sample_region_kwargs=dict(rack_index=0),
                     size=(0.3, 0.25),
                     pos=(0, -1.0),
                 ),

--- a/robocasa/environments/kitchen/composite/garnishing_dishes/garnish_pancake.py
+++ b/robocasa/environments/kitchen/composite/garnishing_dishes/garnish_pancake.py
@@ -52,7 +52,7 @@ class GarnishPancake(Kitchen):
                     fixture=self.fridge,
                     size=(0.15, 0.15),
                     pos=(0, -1.0),
-                    sample_region_kwargs=dict(z_range=(1.0, 1.5)),
+                    sample_region_kwargs=dict(z_range=(0.5, 1.0)),
                 ),
             )
         )

--- a/robocasa/environments/kitchen/composite/loading_dishwasher/load_dishwasher.py
+++ b/robocasa/environments/kitchen/composite/loading_dishwasher/load_dishwasher.py
@@ -13,6 +13,9 @@ class LoadDishwasher(Kitchen):
         Close the dishwasher fully.
     """
 
+    # Counter-local meters: shift the shared dish region 15 cm left.
+    DISH_SAMPLING_OFFSET = (-0.15, 0.0)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -119,6 +122,7 @@ class LoadDishwasher(Kitchen):
                     ),
                     size=(0.35, 0.25),
                     pos=("ref", -1.0),
+                    offset=self.DISH_SAMPLING_OFFSET,
                 ),
             )
         )
@@ -135,6 +139,7 @@ class LoadDishwasher(Kitchen):
                     ),
                     size=(0.35, 0.25),
                     pos=("ref", -1.0),
+                    offset=self.DISH_SAMPLING_OFFSET,
                 ),
             )
         )

--- a/robocasa/environments/kitchen/composite/portioning_meals/portion_peaches.py
+++ b/robocasa/environments/kitchen/composite/portioning_meals/portion_peaches.py
@@ -1,17 +1,17 @@
 from robocasa.environments.kitchen.kitchen import *
 
 
-class PortionHotDogs(Kitchen):
+class PortionPeaches(Kitchen):
     """
-    Portion Hot Dogs: composite task for Portioning Meals activity.
+    Portion Peaches: composite task for Portioning Meals activity.
 
-    Simulates the task of portioning hot dog buns and sausages from a bowl into plates.
-    The task involves taking 2 hot dog buns and 2 sausages from a bowl on the dining counter
-    and placing exactly 1 bun and 1 sausage on each of the 2 plates.
+    Simulates the task of portioning peaches from a bowl into plates.
+    The task involves taking 2 peaches from a bowl on the dining counter
+    and placing exactly 1 peach on each of the 2 plates.
 
     Steps:
-        1. Take hot dog buns and sausages from the bowl on the dining counter
-        2. Place exactly 1 bun and 1 sausage on each plate
+        1. Take the peaches from the bowl on the dining counter
+        2. Place exactly 1 peach on each plate
     """
 
     EXCLUDE_LAYOUTS = Kitchen.DINING_COUNTER_EXCLUDED_LAYOUTS + [22, 58]
@@ -59,7 +59,7 @@ class PortionHotDogs(Kitchen):
         else:
             ep_meta[
                 "lang"
-            ] = "Place one bun and one sausage from the bowl on each plate."
+            ] = "Place one peach from the bowl on each plate."
         return ep_meta
 
     def _setup_scene(self):
@@ -115,8 +115,8 @@ class PortionHotDogs(Kitchen):
 
         cfgs.append(
             dict(
-                name="hotdog_bun1",
-                obj_groups="hotdog_bun",
+                name="peach1",
+                obj_groups="peach",
                 graspable=True,
                 placement=dict(
                     object="bowl",
@@ -127,32 +127,8 @@ class PortionHotDogs(Kitchen):
 
         cfgs.append(
             dict(
-                name="hotdog_bun2",
-                obj_groups="hotdog_bun",
-                graspable=True,
-                placement=dict(
-                    object="bowl",
-                    size=(1.0, 1.0),
-                ),
-            )
-        )
-
-        cfgs.append(
-            dict(
-                name="sausage1",
-                obj_groups="sausage",
-                graspable=True,
-                placement=dict(
-                    object="bowl",
-                    size=(1.0, 1.0),
-                ),
-            )
-        )
-
-        cfgs.append(
-            dict(
-                name="sausage2",
-                obj_groups="sausage",
+                name="peach2",
+                obj_groups="peach",
                 graspable=True,
                 placement=dict(
                     object="bowl",
@@ -164,34 +140,24 @@ class PortionHotDogs(Kitchen):
         return cfgs
 
     def _check_success(self):
-        buns_in_plate1 = 0
-        sausages_in_plate1 = 0
-        for bun_name in ["hotdog_bun1", "hotdog_bun2"]:
-            if OU.check_obj_in_receptacle(self, bun_name, "plate1"):
-                buns_in_plate1 += 1
-        for sausage_name in ["sausage1", "sausage2"]:
-            if OU.check_obj_in_receptacle(self, sausage_name, "plate1"):
-                sausages_in_plate1 += 1
+        peaches_in_plate1 = 0
+        for peach_name in ["peach1", "peach2"]:
+            if OU.check_obj_in_receptacle(self, peach_name, "plate1"):
+                peaches_in_plate1 += 1
 
-        buns_in_plate2 = 0
-        sausages_in_plate2 = 0
-        for bun_name in ["hotdog_bun1", "hotdog_bun2"]:
-            if OU.check_obj_in_receptacle(self, bun_name, "plate2"):
-                buns_in_plate2 += 1
-        for sausage_name in ["sausage1", "sausage2"]:
-            if OU.check_obj_in_receptacle(self, sausage_name, "plate2"):
-                sausages_in_plate2 += 1
+        peaches_in_plate2 = 0
+        for peach_name in ["peach1", "peach2"]:
+            if OU.check_obj_in_receptacle(self, peach_name, "plate2"):
+                peaches_in_plate2 += 1
 
         gripper_far = True
-        for obj_name in ["hotdog_bun1", "hotdog_bun2", "sausage1", "sausage2"]:
+        for obj_name in ["peach1", "peach2"]:
             if not OU.gripper_obj_far(self, obj_name):
                 gripper_far = False
                 break
 
         return (
-            buns_in_plate1 == 1
-            and sausages_in_plate1 == 1
-            and buns_in_plate2 == 1
-            and sausages_in_plate2 == 1
+            peaches_in_plate1 == 1
+            and peaches_in_plate2 == 1
             and gripper_far
         )

--- a/robocasa/environments/kitchen/composite/tidying_cabinets_and_drawers/drawer_cake_sort.py
+++ b/robocasa/environments/kitchen/composite/tidying_cabinets_and_drawers/drawer_cake_sort.py
@@ -1,0 +1,67 @@
+from robocasa.environments.kitchen.kitchen import *
+from robocasa.environments.kitchen.atomic.kitchen_drawer import ManipulateDrawer
+
+
+class DrawerCakeSort(ManipulateDrawer):
+    """Open a drawer, place two cakes inside it, and close the drawer.
+
+    Both cakes are sampled from a shallow band along the counter's outer edge
+    so they do not start deep inside the work surface.
+    """
+
+    OUTER_EDGE_SAMPLE_DEPTH = 0.15
+
+    def __init__(self, drawer_id=FixtureType.TOP_DRAWER, *args, **kwargs):
+        super().__init__(behavior="open", drawer_id=drawer_id, *args, **kwargs)
+
+    def _setup_kitchen_references(self):
+        super()._setup_kitchen_references()
+        self.counter = self.register_fixture_ref(
+            "counter", dict(id=FixtureType.COUNTER, ref=self.drawer, size=(0.4, 0.2))
+        )
+
+    def get_ep_meta(self):
+        ep_meta = super().get_ep_meta()
+        ep_meta["lang"] = (
+            "Open the drawer, place both cakes inside it, then close the drawer."
+        )
+        return ep_meta
+
+    def _get_obj_cfgs(self):
+        return [
+            dict(
+                name="cake1",
+                obj_groups="cake",
+                graspable=True,
+                placement=dict(
+                    fixture=self.counter,
+                    sample_region_kwargs=dict(ref=self.drawer),
+                    size=(0.3, self.OUTER_EDGE_SAMPLE_DEPTH),
+                    pos=("ref", -1.0),
+                ),
+            ),
+            dict(
+                name="cake2",
+                obj_groups="cake",
+                graspable=True,
+                placement=dict(
+                    fixture=self.counter,
+                    sample_region_kwargs=dict(ref=self.drawer),
+                    size=(0.5, self.OUTER_EDGE_SAMPLE_DEPTH),
+                    pos=("ref", -1.0),
+                ),
+            ),
+        ]
+
+    def _check_success(self):
+        cakes_inside_drawer = all(
+            OU.obj_inside_of(self, cake_name, self.drawer)
+            and not OU.check_obj_any_counter_contact(self, cake_name)
+            for cake_name in ("cake1", "cake2")
+        )
+        gripper_far = all(
+            OU.gripper_obj_far(self, obj_name=cake_name)
+            for cake_name in ("cake1", "cake2")
+        )
+        drawer_closed = self.drawer.is_closed(env=self)
+        return cakes_inside_drawer and gripper_far and drawer_closed

--- a/robocasa/environments/kitchen/kitchen.py
+++ b/robocasa/environments/kitchen/kitchen.py
@@ -3,6 +3,7 @@ import xml.etree.ElementTree as ET
 from copy import deepcopy
 
 import numpy as np
+import mujoco
 import robosuite.utils.transform_utils as T
 from robosuite.environments.manipulation.manipulation_env import ManipulationEnv
 from robosuite.models.tasks import ManipulationTask
@@ -411,6 +412,9 @@ class Kitchen(ManipulationEnv, metaclass=KitchenEnvMeta):
         use_novel_instructions=False,
     ):
         self.init_robot_base_ref = init_robot_base_ref
+        self.robot_init_offset = EnvUtils.get_task_robot_init_offset(
+            self.__class__.__name__
+        )
 
         self.robot_spawn_deviation_pos_x = robot_spawn_deviation_pos_x
         self.robot_spawn_deviation_pos_y = robot_spawn_deviation_pos_y
@@ -826,8 +830,14 @@ class Kitchen(ManipulationEnv, metaclass=KitchenEnvMeta):
             self.init_robot_base_ori_anchor,
         ) = EnvUtils.init_robot_base_pose(self)
 
+        self._write_robot_base_pose_to_model()
+        self.robot_geom_ids = None
+
+    def _write_robot_base_pose_to_model(self):
+        """Write the final task-selected base pose into the robot MJCF model."""
         robot_model = self.robots[0].robot_model
         from robosuite.models.robots import PandaOmron
+
         if isinstance(robot_model, PandaOmron):
             # placement code only really works for PandaOmron
             robot_model.set_base_xpos([10.0, 10.0, self.init_robot_base_pos_anchor[2]])
@@ -838,8 +848,6 @@ class Kitchen(ManipulationEnv, metaclass=KitchenEnvMeta):
             # called on every hard_reset, so this is re-evaluated each episode.
             robot_model.set_base_xpos(self.init_robot_base_pos_anchor)
             robot_model.set_base_ori(self.init_robot_base_ori_anchor)
-
-        self.robot_geom_ids = None
 
     def _create_objects(self):
         """
@@ -1089,7 +1097,35 @@ class Kitchen(ManipulationEnv, metaclass=KitchenEnvMeta):
         # consistent physics
         self.sim.set_state(initial_state_copy)
 
+    def _initialize_sim(self, xml_string=None):
+        super()._initialize_sim(xml_string=xml_string)
+        self._robot_init_reset_solver = None
+
+        if EnvUtils.get_effective_robot_init_offset(self) == (0.0, 0.0):
+            return
+
+        native_model = self.sim.model._model
+        if native_model.opt.solver == int(mujoco.mjtSolver.mjSOL_NEWTON):
+            # A shifted robot can create redundant fixture contacts while the
+            # kitchen reset settles its objects. CG avoids Newton's singular
+            # Hessian only for that reset phase.
+            self._robot_init_reset_solver = int(native_model.opt.solver)
+            native_model.opt.solver = int(mujoco.mjtSolver.mjSOL_CG)
+
+    def _restore_robot_init_reset_solver(self):
+        if self._robot_init_reset_solver is None:
+            return
+
+        self.sim.model._model.opt.solver = self._robot_init_reset_solver
+        self._robot_init_reset_solver = None
+
     def _reset_internal(self):
+        try:
+            self._reset_internal_impl()
+        finally:
+            self._restore_robot_init_reset_solver()
+
+    def _reset_internal_impl(self):
         """
         Resets simulation internal configurations.
         """
@@ -1116,7 +1152,9 @@ class Kitchen(ManipulationEnv, metaclass=KitchenEnvMeta):
             self.init_robot_base_pos = self._ep_meta["init_robot_base_pos"]
             self.init_robot_base_ori = self._ep_meta["init_robot_base_ori"]
             EnvUtils.set_robot_to_position(self, self.init_robot_base_pos)
-            self.sim.forward()
+            # SonicG1 has no runtime base translation; its XML base position is final.
+            if not EnvUtils.is_sonic_g1(self):
+                self.sim.forward()
         else:
             robot_pos = EnvUtils.set_robot_base(
                 env=self,
@@ -1207,8 +1245,24 @@ class Kitchen(ManipulationEnv, metaclass=KitchenEnvMeta):
         ep_meta["cam_configs"] = deepcopy(self._cam_configs)
         ep_meta["init_robot_base_pos"] = list(self.init_robot_base_pos)
         ep_meta["init_robot_base_ori"] = list(self.init_robot_base_ori)
+        ep_meta["robot_init_offset"] = list(
+            EnvUtils.get_effective_robot_init_offset(self)
+        )
 
         return ep_meta
+
+    def set_ep_meta(self, meta):
+        super().set_ep_meta(meta)
+        if "robot_init_offset" in meta:
+            self.robot_init_offset = EnvUtils.normalize_robot_init_offset(
+                meta["robot_init_offset"]
+            )
+
+    def unset_ep_meta(self):
+        super().unset_ep_meta()
+        self.robot_init_offset = EnvUtils.get_task_robot_init_offset(
+            self.__class__.__name__
+        )
 
     def edit_model_xml(self, xml_str):
         """

--- a/robocasa/environments/kitchen/kitchen.py
+++ b/robocasa/environments/kitchen/kitchen.py
@@ -46,6 +46,11 @@ import re
 
 
 REGISTERED_KITCHEN_ENVS = {}
+_MUJOCO_SOLVER_XML_NAMES = {
+    "PGS": "PGS",
+    "CG": "CG",
+    "NEWTON": "Newton",
+}
 SLIDING_INTERIOR_FIXTURES = [
     FixtureType.DRAWER,
     FixtureType.DISHWASHER,
@@ -174,6 +179,9 @@ class Kitchen(ManipulationEnv, metaclass=KitchenEnvMeta):
         renderer (str): Specifies which renderer to use.
 
         renderer_config (dict): dictionary for the renderer configurations
+
+        mujoco_solver (str): optional MuJoCo constraint solver. Supported values are
+            "PGS", "CG", and "NEWTON". None preserves MuJoCo's default.
 
         init_robot_base_ref (str): name of the fixture to place the near. If None, will randomly select a fixture.
 
@@ -388,6 +396,7 @@ class Kitchen(ManipulationEnv, metaclass=KitchenEnvMeta):
         camera_depths=False,
         renderer="mjviewer",
         renderer_config=None,
+        mujoco_solver=None,
         init_robot_base_ref=None,
         seed=None,
         layout_and_style_ids=None,
@@ -411,6 +420,14 @@ class Kitchen(ManipulationEnv, metaclass=KitchenEnvMeta):
         use_cotraining_cameras=False,
         use_novel_instructions=False,
     ):
+        if mujoco_solver is not None:
+            solver_key = str(mujoco_solver).upper()
+            if solver_key not in _MUJOCO_SOLVER_XML_NAMES:
+                raise ValueError(
+                    "mujoco_solver must be one of: PGS, CG, NEWTON, or None"
+                )
+            mujoco_solver = _MUJOCO_SOLVER_XML_NAMES[solver_key]
+        self.mujoco_solver = mujoco_solver
         self.init_robot_base_ref = init_robot_base_ref
         self.robot_init_offset = EnvUtils.get_task_robot_init_offset(
             self.__class__.__name__
@@ -1279,6 +1296,12 @@ class Kitchen(ManipulationEnv, metaclass=KitchenEnvMeta):
 
         tree = ET.fromstring(xml_str)
         root = tree
+        if self.mujoco_solver is not None:
+            option = root.find("option")
+            if option is None:
+                option = ET.Element("option")
+                root.insert(0, option)
+            option.set("solver", self.mujoco_solver)
         worldbody = root.find("worldbody")
         actuator = root.find("actuator")
         asset = root.find("asset")

--- a/robocasa/scripts/collect_sonic_demos.py
+++ b/robocasa/scripts/collect_sonic_demos.py
@@ -79,6 +79,8 @@ def reset_with_retry(env, base, args, tries=12):
     # FactorizeHessian on the reset mj_forward. Each reset re-samples the kitchen, so retry.
     last = None
     for k in range(tries):
+        # Episode capture serializes fixture refs; fresh samples must not reuse that metadata.
+        base.unset_ep_meta()
         try:
             ret = env.reset()
             _apply_runtime(base, args)

--- a/robocasa/scripts/collect_sonic_demos.py
+++ b/robocasa/scripts/collect_sonic_demos.py
@@ -10,6 +10,7 @@ Start the C++ SONIC controller (publishes lowcmd to DDS) first, then run this on
 display (do NOT set MUJOCO_GL=egl).
 """
 import argparse
+from copy import deepcopy
 import datetime
 import json
 import os
@@ -44,11 +45,15 @@ def _controller(base):
     return base.robots[0].composite_controller
 
 
-def _print_instruction(base):
-    # match the traditional robocasa collector: announce the task's language goal each episode
-    lang = base.get_ep_meta().get("lang")
-    if lang:
-        print(colored(f"Instruction: {lang}", "green"), flush=True)
+def _snapshot_and_print_instruction(base):
+    """Capture the sampled episode metadata exactly once and announce its goal."""
+    ep_meta = base.get_ep_meta()
+    base.set_ep_meta(ep_meta)
+    lang = ep_meta.get("lang")
+    instruction = lang.strip() if isinstance(lang, str) and lang.strip() else None
+    if instruction:
+        print(colored(f"Instruction: {instruction}", "green"), flush=True)
+    return ep_meta, instruction
 
 
 def make_env(args, cfg):
@@ -83,16 +88,30 @@ def _apply_runtime(base, args):
 def reset_with_retry(env, base, args, tries=12):
     # Keep a reset fallback for invalid placements and other fatal simulation errors.
     last = None
+    reset_started = time.perf_counter()
     for k in range(tries):
+        attempt_started = time.perf_counter()
         # Episode capture serializes fixture refs; fresh samples must not reuse that metadata.
         base.unset_ep_meta()
         try:
             ret = env.reset()
             _apply_runtime(base, args)
+            print(
+                f"[sonic-timing] env.reset ready in "
+                f"{time.perf_counter() - reset_started:.3f}s "
+                f"(attempt {k + 1}, current attempt "
+                f"{time.perf_counter() - attempt_started:.3f}s)",
+                flush=True,
+            )
             return ret
         except mujoco.FatalError as e:
             last = e
-            print(f"[sonic] reset solver error; re-sampling ({k + 2}/{tries})", flush=True)
+            print(
+                f"[sonic] reset solver error after "
+                f"{time.perf_counter() - attempt_started:.3f}s; "
+                f"re-sampling ({k + 2}/{tries})",
+                flush=True,
+            )
     raise last
 
 
@@ -115,6 +134,21 @@ def _valid_sonic_gains(gains):
 def _copy_sonic_gains(gains):
     return {k: (np.asarray(kp, dtype=float).copy(), np.asarray(kd, dtype=float).copy())
             for k, (kp, kd) in gains.items()}
+
+
+def _resolve_episode_event(pressed, vr_events, recording):
+    """Merge local and VR lifecycle events with deterministic abort-first priority."""
+    local_abort = "x" in pressed
+    vr_abort = "toggle_data_abort" in vr_events
+    if local_abort or vr_abort:
+        return ("discard", vr_abort) if recording else (None, vr_abort)
+
+    vr_toggle = "toggle_data_collection" in vr_events
+    if recording and ("k" in pressed or vr_toggle):
+        return "save", vr_toggle
+    if not recording and ("c" in pressed or vr_toggle):
+        return "start", vr_toggle
+    return None, False
 
 
 def _sonic_runtime_json(args):
@@ -200,7 +234,23 @@ class SonicDataCollectionWrapper(DataCollectionWrapper):
         return state
 
     def _on_first_interaction(self):
-        super()._on_first_interaction()
+        # DataCollectionWrapper calls env.get_ep_meta() here. Use the exact
+        # snapshot already published to the exporter instead, because novel
+        # instruction generators may otherwise sample a second string.
+        self.has_interaction = True
+        t1, t2 = str(time.time()).split(".")
+        self.ep_directory = os.path.join(self.directory, f"ep_{t1}_{t2}")
+        assert not os.path.exists(self.ep_directory)
+        print(f"DataCollectionWrapper: making folder at {self.ep_directory}")
+        os.makedirs(self.ep_directory)
+
+        with open(os.path.join(self.ep_directory, "model.xml"), "w", encoding="utf-8") as f:
+            f.write(self._current_task_instance_xml)
+        with open(os.path.join(self.ep_directory, "ep_meta.json"), "w", encoding="utf-8") as f:
+            json.dump(self._current_task_instance_ep_meta, f)
+
+        assert len(self.states) == 0
+        self.states.append(self._current_task_instance_state)
         self.integration_states.append(self._current_task_instance_integration_state)
 
     def _flush(self):
@@ -234,7 +284,7 @@ class SonicDataCollectionWrapper(DataCollectionWrapper):
             self.action_infos.append({"actions": np.asarray(action, dtype=float)})
         return ret
 
-    def start_episode_from_current_state(self):
+    def start_episode_from_current_state(self, ep_meta=None):
         if self.has_interaction:
             self._flush()
         self.t = 0
@@ -246,7 +296,12 @@ class SonicDataCollectionWrapper(DataCollectionWrapper):
         self._current_task_instance_xml = self.env.model.get_xml()
         self._current_task_instance_state = np.array(self.env.sim.get_state().flatten())
         self._current_task_instance_integration_state = self._integration_state_for(self.env)
-        self.env.set_ep_meta(self.env.get_ep_meta())
+        # Reuse the metadata snapshot already sent to the VLA exporter. Some
+        # novel-instruction tasks sample text inside get_ep_meta(), so reading it
+        # again here could give the raw demo and LeRobot export different labels.
+        selected_ep_meta = ep_meta if ep_meta is not None else self.env.get_ep_meta()
+        self._current_task_instance_ep_meta = deepcopy(selected_ep_meta)
+        self.env.set_ep_meta(deepcopy(selected_ep_meta))
 
 
 def run_collection(args, base, wall, env_kwargs, source):
@@ -261,6 +316,7 @@ def run_collection(args, base, wall, env_kwargs, source):
 
     manager_sub = None
     keyboard_pub = None
+    instruction_pub = None
     image_pub = None
     if args.vla_stream:
         from robocasa.utils.sonic_vla_streaming import (
@@ -268,6 +324,7 @@ def run_collection(args, base, wall, env_kwargs, source):
             RoboCasaVLACameraPublisher,
             VLACameraConfig,
             VLAExporterKeyboardPublisher,
+            VLAExporterInstructionPublisher,
         )
 
         image_pub = RoboCasaVLACameraPublisher(
@@ -287,6 +344,11 @@ def run_collection(args, base, wall, env_kwargs, source):
         manager_sub = ManagerStateSubscriber(args.vla_manager_host, args.vla_manager_port)
         if args.vla_keyboard_sync:
             keyboard_pub = VLAExporterKeyboardPublisher(args.vla_keyboard_port)
+        if args.vla_instruction_sync:
+            instruction_pub = VLAExporterInstructionPublisher(
+                args.vla_instruction_port,
+                repeat_interval=args.vla_instruction_heartbeat,
+            )
         print(
             f"[sonic-vla] publishing {','.join(args.vla_camera_keys)} "
             f"from {','.join(args.vla_camera_names)} "
@@ -297,9 +359,30 @@ def run_collection(args, base, wall, env_kwargs, source):
     hold = np.zeros(base.action_dim)
     saved, recording, gains, saved_gains = [], False, None, None
     next_t = time.perf_counter()
+    instruction_sequence = 0
+    current_ep_meta = None
+    current_instruction = None
     print(f"[sonic] dataset dir: {demo_dir}", flush=True)
     print("[sonic] press 'b' to drop the band once balancing, then 'c' to record.", flush=True)
-    _print_instruction(base)
+
+    def announce_episode():
+        nonlocal current_ep_meta, current_instruction, instruction_sequence
+        current_ep_meta, current_instruction = _snapshot_and_print_instruction(base)
+        if instruction_pub is not None:
+            episode_id = f"{ts}:{instruction_sequence:06d}"
+            instruction_pub.set_episode(
+                current_instruction,
+                episode_id=episode_id,
+                sequence=instruction_sequence,
+            )
+            source_label = current_instruction or "<CLI --task-prompt fallback>"
+            print(
+                f"[sonic-vla] episode instruction {episode_id} -> {source_label}",
+                flush=True,
+            )
+        instruction_sequence += 1
+
+    announce_episode()
 
     def sync_exporter(key, from_vr=False, delay=True):
         if not args.vla_stream:
@@ -310,11 +393,12 @@ def run_collection(args, base, wall, env_kwargs, source):
             time.sleep(args.vla_save_sync_delay)
 
     def finish(discard):
-        nonlocal recording, saved_gains
+        nonlocal recording, saved_gains, next_t
         ep = env.ep_directory
         if not env.has_interaction or ep is None:
             recording = False
             return
+        transition_started = time.perf_counter()
         name = os.path.basename(ep)
         if env.states:
             env._flush()
@@ -332,9 +416,23 @@ def run_collection(args, base, wall, env_kwargs, source):
             if h:
                 convert_to_robomimic_format(h, filter_num_demos=None)
             print(f"[sonic] saved {name}", flush=True)
+        finalize_finished = time.perf_counter()
         reset_with_retry(wall, base, args)
+        reset_finished = time.perf_counter()
         source.reset(base)
-        _print_instruction(base)
+        announce_episode()
+        ready_at = time.perf_counter()
+        # A hard reset and optional HDF5 conversion can take seconds. Do not
+        # make the 200 Hz loop chase those expired wall-clock deadlines.
+        next_t = ready_at
+        print(
+            f"[sonic-timing] episode {'discard' if discard else 'save'} transition: "
+            f"finalize={finalize_finished - transition_started:.3f}s, "
+            f"reset={reset_finished - finalize_finished:.3f}s, "
+            f"source+instruction={ready_at - reset_finished:.3f}s, "
+            f"total={ready_at - transition_started:.3f}s",
+            flush=True,
+        )
 
     def recover_from_step_error(err):
         nonlocal recording, next_t
@@ -348,43 +446,40 @@ def run_collection(args, base, wall, env_kwargs, source):
             recording = False
         reset_with_retry(wall, base, args)
         source.reset(base)
-        _print_instruction(base)
+        announce_episode()
         next_t = time.perf_counter()
 
     try:
         while True:
+            if instruction_pub is not None:
+                instruction_pub.maybe_publish()
             p = keys.consume()
             vr_events = manager_sub.poll() if manager_sub is not None else set()
-            if "toggle_data_collection" in vr_events:
-                p.add("vla_toggle")
-            if "toggle_data_abort" in vr_events:
-                p.add("vla_discard")
             if "b" in p:
                 _controller(base).toggle_band()
-            local_start = "c" in p and not recording
-            vr_start = "vla_toggle" in p and not recording
-            local_save = "k" in p and recording
-            vr_save = "vla_toggle" in p and recording
-            local_discard = "x" in p and recording
-            vr_discard = "vla_discard" in p and recording
+            episode_event, from_vr = _resolve_episode_event(p, vr_events, recording)
 
-            if local_start or vr_start:
+            if episode_event == "start":
                 if gains is None:
                     print("[sonic] not engaged yet -- cannot record.", flush=True)
-                    if vr_start and keyboard_pub is not None:
+                    if from_vr and keyboard_pub is not None:
                         keyboard_pub.send("x")
                 else:
-                    if local_start:
+                    if instruction_pub is not None:
+                        instruction_pub.mark_start()
+                        if args.vla_instruction_start_delay > 0:
+                            time.sleep(args.vla_instruction_start_delay)
+                    if not from_vr:
                         sync_exporter("c", from_vr=False, delay=False)
-                    env.start_episode_from_current_state()
+                    env.start_episode_from_current_state(ep_meta=current_ep_meta)
                     recording = True
                     print("[sonic] recording...", flush=True)
-            if local_save or vr_save:
-                sync_exporter("c", from_vr=vr_save)
+            elif episode_event == "save":
+                sync_exporter("c", from_vr=from_vr)
                 finish(discard=False)
                 continue
-            if local_discard or vr_discard:
-                sync_exporter("x", from_vr=vr_discard)
+            elif episode_event == "discard":
+                sync_exporter("x", from_vr=from_vr)
                 finish(discard=True)
                 continue
 
@@ -416,6 +511,8 @@ def run_collection(args, base, wall, env_kwargs, source):
             manager_sub.close()
         if keyboard_pub is not None:
             keyboard_pub.close()
+        if instruction_pub is not None:
+            instruction_pub.close()
         if image_pub is not None:
             image_pub.close()
         if saved:
@@ -486,7 +583,23 @@ def get_args():
                     help="run_data_exporter.py ZMQ keyboard port")
     ap.add_argument("--no-vla-keyboard-sync", dest="vla_keyboard_sync", action="store_false",
                     help="Do not forward local c/k/x hotkeys to run_data_exporter.py")
-    ap.set_defaults(vla_keyboard_sync=True, vla_camera_flip=False)
+    ap.add_argument("--vla-instruction-port", type=int, default=5581,
+                    help="ZMQ port for per-episode RoboCasa instruction metadata")
+    ap.add_argument(
+        "--no-vla-instruction-sync",
+        dest="vla_instruction_sync",
+        action="store_false",
+        help="Do not publish sampled episode instructions to run_data_exporter.py",
+    )
+    ap.add_argument("--vla-instruction-heartbeat", type=float, default=0.5,
+                    help="Seconds between repeats of the current episode instruction")
+    ap.add_argument("--vla-instruction-start-delay", type=float, default=0.05,
+                    help="Local-start grace period for exporter instruction receipt (seconds)")
+    ap.set_defaults(
+        vla_keyboard_sync=True,
+        vla_instruction_sync=True,
+        vla_camera_flip=False,
+    )
     ap.add_argument("--vla-save-sync-delay", type=float, default=0.08,
                     help="Small episode-end delay so run_data_exporter.py sees save/discard before reset")
     args = ap.parse_args()
@@ -499,6 +612,10 @@ def get_args():
         ap.error("--vla-camera-names and --vla-camera-keys must have the same length")
     if len(set(args.vla_camera_keys)) != len(args.vla_camera_keys):
         ap.error("--vla-camera-keys must be unique")
+    if args.vla_instruction_heartbeat <= 0:
+        ap.error("--vla-instruction-heartbeat must be positive")
+    if args.vla_instruction_start_delay < 0:
+        ap.error("--vla-instruction-start-delay must be non-negative")
     return args
 
 

--- a/robocasa/scripts/collect_sonic_demos.py
+++ b/robocasa/scripts/collect_sonic_demos.py
@@ -55,8 +55,9 @@ def make_env(args, cfg):
     env = robosuite.make(
         args.environment, robots=[args.robot], controller_configs=cfg,
         has_renderer=True, has_offscreen_renderer=False, use_camera_obs=False, ignore_done=True,
-        renderer="mjviewer", render_camera="robot0_frontview",
+        renderer="mjviewer", render_camera=args.render_camera,
         layout_ids=args.layout, style_ids=args.style, control_freq=args.control_freq,
+        initialization_noise=None,
     )
     env_kwargs = dict(robots=[args.robot], controller_configs=cfg, initialization_noise=None,
                       use_camera_obs=False, translucent_robot=False,
@@ -265,6 +266,8 @@ def run_collection(args, base, wall, env_kwargs, source):
             VLACameraConfig(
                 camera_name=args.vla_camera_name,
                 output_key=args.vla_camera_key,
+                camera_names=args.vla_camera_names,
+                output_keys=args.vla_camera_keys,
                 width=args.vla_camera_width,
                 height=args.vla_camera_height,
                 hz=args.vla_camera_hz,
@@ -277,7 +280,8 @@ def run_collection(args, base, wall, env_kwargs, source):
         if args.vla_keyboard_sync:
             keyboard_pub = VLAExporterKeyboardPublisher(args.vla_keyboard_port)
         print(
-            f"[sonic-vla] publishing {args.vla_camera_key} from {args.vla_camera_name} "
+            f"[sonic-vla] publishing {','.join(args.vla_camera_keys)} "
+            f"from {','.join(args.vla_camera_names)} "
             f"at {args.vla_camera_hz:g} Hz on port {args.vla_camera_port}",
             flush=True,
         )
@@ -425,6 +429,14 @@ def get_args():
     ap.add_argument("--layout", type=int, default=1, help="kitchen layout id")
     ap.add_argument("--style", type=int, default=None, help="kitchen style id (None=random)")
     ap.add_argument("--robot", default="SonicG1", help="SonicG1 or SonicG1Fixed")
+    ap.add_argument(
+        "--render-camera",
+        default="robot0_frontview",
+        help=(
+            "MuJoCo camera used by the interactive viewer; "
+            "use robot0_head_camera for robot first-person view"
+        ),
+    )
     ap.add_argument("--out", default="/tmp/sonic_robocasa_demos", help="output dataset directory")
     ap.add_argument("--record-freq", type=int, default=1, help="record one sample every N steps")
     ap.add_argument("--sim-dt", type=float, default=0.005, help="physics timestep (s); 200 Hz")
@@ -443,9 +455,13 @@ def get_args():
     ap.add_argument("--vla-camera-port", type=int, default=5555,
                     help="ZMQ port for the RoboCasa VLA camera stream")
     ap.add_argument("--vla-camera-name", default="robot0_head_camera",
-                    help="MuJoCo camera rendered as the VLA ego_view stream")
+                    help="MuJoCo camera rendered as the single VLA image stream")
     ap.add_argument("--vla-camera-key", default="ego_view",
-                    help="Image key expected by run_data_exporter.py")
+                    help="Image key expected by run_data_exporter.py for single-camera streaming")
+    ap.add_argument("--vla-camera-names", nargs="+", default=None,
+                    help="MuJoCo cameras rendered into one VLA camera message")
+    ap.add_argument("--vla-camera-keys", nargs="+", default=None,
+                    help="Image keys for --vla-camera-names, e.g. ego_view left_wrist right_wrist")
     ap.add_argument("--vla-camera-width", type=int, default=640)
     ap.add_argument("--vla-camera-height", type=int, default=480)
     ap.add_argument("--vla-camera-hz", type=float, default=30.0,
@@ -465,7 +481,17 @@ def get_args():
     ap.set_defaults(vla_keyboard_sync=True, vla_camera_flip=False)
     ap.add_argument("--vla-save-sync-delay", type=float, default=0.08,
                     help="Small episode-end delay so run_data_exporter.py sees save/discard before reset")
-    return ap.parse_args()
+    args = ap.parse_args()
+    if (args.vla_camera_names is None) != (args.vla_camera_keys is None):
+        ap.error("--vla-camera-names and --vla-camera-keys must be provided together")
+    if args.vla_camera_names is None:
+        args.vla_camera_names = [args.vla_camera_name]
+        args.vla_camera_keys = [args.vla_camera_key]
+    if len(args.vla_camera_names) != len(args.vla_camera_keys):
+        ap.error("--vla-camera-names and --vla-camera-keys must have the same length")
+    if len(set(args.vla_camera_keys)) != len(args.vla_camera_keys):
+        ap.error("--vla-camera-keys must be unique")
+    return args
 
 
 def main():

--- a/robocasa/scripts/collect_sonic_demos.py
+++ b/robocasa/scripts/collect_sonic_demos.py
@@ -35,6 +35,10 @@ from robocasa.utils.robomimic.robomimic_dataset_utils import convert_to_robomimi
 from robocasa.wrappers.enclosing_wall_render_wrapper import EnclosingWallRenderWrapper
 
 
+# PGS avoids Newton's sparse Hessian factorization failures under dense contacts.
+SONIC_MUJOCO_SOLVER = "PGS"
+
+
 def _controller(base):
     # recreated on every env.reset() (robot.reset -> _load_controller) -> always fetch fresh
     return base.robots[0].composite_controller
@@ -57,11 +61,12 @@ def make_env(args, cfg):
         has_renderer=True, has_offscreen_renderer=False, use_camera_obs=False, ignore_done=True,
         renderer="mjviewer", render_camera=args.render_camera,
         layout_ids=args.layout, style_ids=args.style, control_freq=args.control_freq,
-        initialization_noise=None,
+        initialization_noise=None, mujoco_solver=SONIC_MUJOCO_SOLVER,
     )
     env_kwargs = dict(robots=[args.robot], controller_configs=cfg, initialization_noise=None,
                       use_camera_obs=False, translucent_robot=False,
-                      layout_ids=args.layout, style_ids=args.style, control_freq=args.control_freq)
+                      layout_ids=args.layout, style_ids=args.style, control_freq=args.control_freq,
+                      mujoco_solver=SONIC_MUJOCO_SOLVER)
     return env, env_kwargs
 
 
@@ -70,13 +75,13 @@ def _apply_runtime(base, args):
     # control loop. Re-applied after each reset (hard reset rebuilds the model).
     match_base_sim_physics(base.sim.model._model, args.floor_friction, args.floor_torsion,
                            timestep=args.sim_dt)
+    base.sim.model._model.opt.solver = int(mujoco.mjtSolver.mjSOL_PGS)
     base.post_action_freq = max(1, round(args.control_freq / args.post_action_hz))
     base.render_freq = max(1, round(args.control_freq / args.render_hz))
 
 
 def reset_with_retry(env, base, args, tries=12):
-    # robocasa spawns the robot near a fixture; some samples penetrate it and the solver raises
-    # FactorizeHessian on the reset mj_forward. Each reset re-samples the kitchen, so retry.
+    # Keep a reset fallback for invalid placements and other fatal simulation errors.
     last = None
     for k in range(tries):
         # Episode capture serializes fixture refs; fresh samples must not reuse that metadata.
@@ -124,6 +129,7 @@ def _sonic_runtime_json(args):
         "render_freq": int(render_freq),
         "floor_friction": float(args.floor_friction),
         "floor_torsion": float(args.floor_torsion),
+        "mujoco_solver": SONIC_MUJOCO_SOLVER,
         "mujoco_state_spec": "mjSTATE_INTEGRATION",
     })
 
@@ -507,8 +513,9 @@ def main():
     wall = EnclosingWallRenderWrapper(base, alpha=args.wall_alpha, enabled=True)
     reset_with_retry(wall, base, args)
     n_sub = int(round(base.control_timestep / base.model_timestep))
+    solver = mujoco.mjtSolver(base.sim.model._model.opt.solver).name.removeprefix("mjSOL_")
     print(f"[sonic] {1.0/args.sim_dt:.0f} Hz physics | control_freq {args.control_freq} | "
-          f"{n_sub} substep(s)/step", flush=True)
+          f"{n_sub} substep(s)/step | solver {solver}", flush=True)
 
     source = DDSActionSource(_controller(base)._cfg)
     source.reset(base)

--- a/robocasa/scripts/collect_sonic_demos.py
+++ b/robocasa/scripts/collect_sonic_demos.py
@@ -17,6 +17,12 @@ import os
 import threading
 import time
 
+# Editable RoboSuite checkouts do not always provide Numba with a source-cache
+# locator. Keep compiled artifacts outside the repository and isolate users.
+os.environ.setdefault(
+    "NUMBA_CACHE_DIR", f"/tmp/robocasa-numba-cache-{os.getuid()}"
+)
+
 import h5py
 import mujoco
 import numpy as np
@@ -531,7 +537,12 @@ def get_args():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--environment", default="Kitchen", help="robocasa kitchen env name")
-    ap.add_argument("--layout", type=int, default=1, help="kitchen layout id")
+    ap.add_argument(
+        "--layout",
+        type=int,
+        default=-1,
+        help="kitchen layout id (-1=random compatible test layout)",
+    )
     ap.add_argument("--style", type=int, default=None, help="kitchen style id (None=random)")
     ap.add_argument("--robot", default="SonicG1", help="SonicG1 or SonicG1Fixed")
     ap.add_argument(

--- a/robocasa/utils/env_utils.py
+++ b/robocasa/utils/env_utils.py
@@ -48,6 +48,13 @@ _ROBOT_POS_OFFSETS: dict[str, list[float]] = {
     "H1":[0, -0.1, -0.05],
 }
 
+_DEFAULT_TASK_ROBOT_INIT_OFFSET = (0.0, 0.0)
+_TASK_ROBOT_INIT_OFFSETS: dict[str, tuple[float, float]] = {
+    # (lateral, longitudinal) in the SonicG1 robot frame, in meters.
+    "SlideDishwasherRack": (-0.50, 0.0),
+    "PickPlaceDrawerToCounter": (0.0, -0.35),
+}
+
 KITCHEN_SCENES_5X5 = [
     (layout, style) for layout in [11, 15, 18, 40, 50] for style in [14, 28, 34, 46, 58]
 ]
@@ -1331,6 +1338,56 @@ def _get_placement_initializer(env, cfg_list, z_offset=0.01):
     return placement_initializer
 
 
+def get_task_robot_init_offset(task_name):
+    return _TASK_ROBOT_INIT_OFFSETS.get(task_name, _DEFAULT_TASK_ROBOT_INIT_OFFSET)
+
+
+def is_sonic_g1(env):
+    robots = getattr(env, "robots", [])
+    robot = robots[0] if robots else None
+    robot_model = getattr(robot, "robot_model", None)
+    return robot_model is not None and type(robot_model).__name__ == "SonicG1"
+
+
+def get_effective_robot_init_offset(env):
+    if not is_sonic_g1(env):
+        return _DEFAULT_TASK_ROBOT_INIT_OFFSET
+    return normalize_robot_init_offset(
+        getattr(
+            env,
+            "robot_init_offset",
+            get_task_robot_init_offset(env.__class__.__name__),
+        )
+    )
+
+
+def normalize_robot_init_offset(offset):
+    try:
+        normalized_offset = np.asarray(offset, dtype=float)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "robot_init_offset must contain exactly two finite values"
+        ) from exc
+    if normalized_offset.shape != (2,) or not np.isfinite(normalized_offset).all():
+        raise ValueError("robot_init_offset must contain exactly two finite values")
+    return tuple(normalized_offset.tolist())
+
+
+def apply_robot_init_offset(robot_base_pos, robot_base_ori, offset):
+    """Apply a (lateral, longitudinal) offset in the robot base frame.
+
+    Lateral values are positive to the robot right; longitudinal values are
+    positive forward.
+    """
+    lateral, longitudinal = normalize_robot_init_offset(offset)
+    yaw = float(robot_base_ori[2])
+    adjusted_pos = np.asarray(robot_base_pos, dtype=float).copy()
+    adjusted_pos[:2] += lateral * np.array(
+        [np.sin(yaw), -np.cos(yaw)]
+    ) + longitudinal * np.array([np.cos(yaw), np.sin(yaw)])
+    return adjusted_pos
+
+
 def init_robot_base_pose(env):
     """
     helper function to initialize robot base pose
@@ -1374,6 +1431,12 @@ def init_robot_base_pose(env):
         env,
         ref_fixture=ref_fixture,
         ref_object=ref_object,
+    )
+
+    robot_base_pos = apply_robot_init_offset(
+        robot_base_pos,
+        robot_base_ori,
+        get_effective_robot_init_offset(env),
     )
 
     return robot_base_pos, robot_base_ori

--- a/robocasa/utils/env_utils.py
+++ b/robocasa/utils/env_utils.py
@@ -53,6 +53,7 @@ _TASK_ROBOT_INIT_OFFSETS: dict[str, tuple[float, float]] = {
     # (lateral, longitudinal) in the SonicG1 robot frame, in meters.
     "SlideDishwasherRack": (-0.50, 0.0),
     "PickPlaceDrawerToCounter": (0.0, -0.35),
+    "CloseFridgeDrawer": (0.0, -0.05),
 }
 
 KITCHEN_SCENES_5X5 = [

--- a/robocasa/utils/env_utils.py
+++ b/robocasa/utils/env_utils.py
@@ -877,6 +877,7 @@ def _check_cfg_is_valid(cfg):
             "anchor_to",
             "object",
             "try_to_place_in_kwargs",
+            "side",
         }
     )
 
@@ -1009,6 +1010,7 @@ def _get_placement_initializer(env, cfg_list, z_offset=0.01):
             "ensure_valid_auxiliary_placement"
         )
         rotation_axis = placement.get("rotation_axis", "z")
+        side = placement.get("side", "all")
         sampler_kwargs = dict(
             name="{}_Sampler".format(cfg["name"]),
             mujoco_objects=mj_obj,
@@ -1018,6 +1020,7 @@ def _get_placement_initializer(env, cfg_list, z_offset=0.01):
             ensure_valid_auxiliary_placement=ensure_valid_auxiliary_placement,
             rotation_axis=rotation_axis,
             rotation=rotation,
+            side=side,
         )
 
         if anchor_to is not None:

--- a/robocasa/utils/object_utils.py
+++ b/robocasa/utils/object_utils.py
@@ -669,6 +669,20 @@ def check_obj_grasped(env, obj_name, threshold=0.035):
     obj = env.objects[obj_name]
     robot = env.robots[0]
 
+    if "right" in robot.gripper:
+        gripper = robot.gripper["right"]
+    else:
+        raise AttributeError("Gripper dictionary does not contain a 'right' key.")
+
+    # The original predicate was written for Panda's two-finger gripper. Sonic's
+    # Dex3 hand has seven joints with mixed closing directions, so applying the
+    # same scalar qpos comparison would reject valid grasps. Dex3 also exposes
+    # collision geoms for the complete hand, making contact the compatible signal
+    # for these tasks (the loose 0.6 / 0.99 thresholds used by the wiping tasks
+    # already make the Panda closure check effectively contact-only).
+    if any("right_hand_" in joint for joint in gripper.joints):
+        return env.check_contact(gripper, obj)
+
     gripper_joints = ["gripper0_right_finger_joint1", "gripper0_right_finger_joint2"]
     gripper_joint_positions = [
         env.sim.data.qpos[env.sim.model.get_joint_qpos_addr(joint)]
@@ -676,11 +690,6 @@ def check_obj_grasped(env, obj_name, threshold=0.035):
     ]
 
     gripper_closed = all(pos < threshold for pos in gripper_joint_positions)
-
-    if "right" in robot.gripper:
-        gripper = robot.gripper["right"]
-    else:
-        raise AttributeError("Gripper dictionary does not contain a 'right' key.")
 
     return env.check_contact(gripper, obj) and gripper_closed
 

--- a/robocasa/utils/placement_samplers.py
+++ b/robocasa/utils/placement_samplers.py
@@ -209,6 +209,7 @@ class UniformRandomSampler(ObjectPositionSampler):
             raise ValueError(
                 "Invalid value for side, must be one of:", self.valid_sides
             )
+        self.side = side
 
         super().__init__(
             name=name,
@@ -236,6 +237,12 @@ class UniformRandomSampler(ObjectPositionSampler):
                 minimum += buffer
                 maximum -= buffer
 
+        midpoint = (minimum + maximum) / 2
+        if self.side in {"left", "front_left", "back_left"}:
+            maximum = midpoint
+        elif self.side in {"right", "front_right", "back_right"}:
+            minimum = midpoint
+
         if minimum > maximum:
             raise PlacementError(
                 f"Invalid x range for placement initializer: ({minimum}, {maximum})"
@@ -256,6 +263,12 @@ class UniformRandomSampler(ObjectPositionSampler):
             if self.ensure_object_boundary_in_range:
                 minimum += buffer
                 maximum -= buffer
+
+        midpoint = (minimum + maximum) / 2
+        if self.side in {"front", "front_left", "front_right"}:
+            maximum = midpoint
+        elif self.side in {"back", "back_left", "back_right"}:
+            minimum = midpoint
 
         if minimum > maximum:
             raise PlacementError(

--- a/robocasa/utils/sonic_vla_streaming.py
+++ b/robocasa/utils/sonic_vla_streaming.py
@@ -135,6 +135,8 @@ class VLAExporterKeyboardPublisher:
 class VLACameraConfig:
     camera_name: str = "robot0_head_camera"
     output_key: str = "ego_view"
+    camera_names: tuple[str, ...] | list[str] | None = None
+    output_keys: tuple[str, ...] | list[str] | None = None
     width: int = 640
     height: int = 480
     hz: float = 30.0
@@ -152,6 +154,18 @@ def _prepare_image(image: np.ndarray, flip_vertical: bool) -> np.ndarray:
     return np.ascontiguousarray(image)
 
 
+def _resolve_names(value, fallback: str, label: str) -> tuple[str, ...]:
+    if value is None:
+        resolved = (fallback,)
+    elif isinstance(value, str):
+        resolved = (value,)
+    else:
+        resolved = tuple(value)
+    if not resolved or any(not item for item in resolved):
+        raise ValueError(f"VLA {label} must contain at least one non-empty value")
+    return resolved
+
+
 class RoboCasaVLACameraPublisher:
     """Publish RoboCasa frames using SONIC's camera-server schema.
 
@@ -163,9 +177,21 @@ class RoboCasaVLACameraPublisher:
         if config.hz <= 0:
             raise ValueError("VLA camera hz must be positive")
         self.config = config
+        self._camera_names = _resolve_names(
+            config.camera_names, config.camera_name, "camera_names"
+        )
+        self._output_keys = _resolve_names(
+            config.output_keys, config.output_key, "output_keys"
+        )
+        if len(self._camera_names) != len(self._output_keys):
+            raise ValueError("VLA camera_names and output_keys must have the same length")
+        if len(set(self._output_keys)) != len(self._output_keys):
+            raise ValueError("VLA output_keys must be unique")
         self._period = 1.0 / float(config.hz)
         self._next_publish_time = 0.0
-        self._queue: queue.Queue[tuple[float, np.ndarray]] = queue.Queue(maxsize=1)
+        self._queue: queue.Queue[
+            tuple[dict[str, float], dict[str, np.ndarray]]
+        ] = queue.Queue(maxsize=1)
         self._stop_event = threading.Event()
         self._ready_event = threading.Event()
         self._thread: threading.Thread | None = None
@@ -194,7 +220,7 @@ class RoboCasaVLACameraPublisher:
         if self._startup_error is not None:
             raise RuntimeError("Failed to start RoboCasa VLA camera publisher") from self._startup_error
         if env is not None:
-            self._get_live_renderer(env)
+            self._render_images(env)
 
     def maybe_publish(self, env) -> bool:
         self._raise_sender_error()
@@ -207,11 +233,22 @@ class RoboCasaVLACameraPublisher:
         else:
             self._next_publish_time += self._period
 
-        renderer, scene_option = self._get_live_renderer(env)
-        renderer.update_scene(env.sim.data._data, camera=self.config.camera_name, scene_option=scene_option)
-        image = renderer.render()
-        self._enqueue_image(time.time(), _prepare_image(image, self.config.flip_vertical))
+        timestamp = time.time()
+        timestamps = {output_key: timestamp for output_key in self._output_keys}
+        images = self._render_images(env)
+        self._enqueue_images(timestamps, images)
         return True
+
+    def _render_images(self, env) -> dict[str, np.ndarray]:
+        renderer, scene_option = self._get_live_renderer(env)
+        images: dict[str, np.ndarray] = {}
+        for camera_name, output_key in zip(self._camera_names, self._output_keys):
+            renderer.update_scene(
+                env.sim.data._data, camera=camera_name, scene_option=scene_option
+            )
+            image = renderer.render()
+            images[output_key] = _prepare_image(image, self.config.flip_vertical)
+        return images
 
     def _raise_sender_error(self):
         if self._startup_error is not None:
@@ -239,16 +276,16 @@ class RoboCasaVLACameraPublisher:
             self._renderer_model = None
             self._scene_option = None
 
-    def _enqueue_image(self, timestamp: float, image: np.ndarray):
+    def _enqueue_images(self, timestamps: dict[str, float], images: dict[str, np.ndarray]):
         try:
-            self._queue.put_nowait((timestamp, image))
+            self._queue.put_nowait((timestamps, images))
         except queue.Full:
             self._increment_drop_count()
             try:
                 self._queue.get_nowait()
             except queue.Empty:
                 pass
-            self._queue.put_nowait((timestamp, image))
+            self._queue.put_nowait((timestamps, images))
 
     def _increment_drop_count(self):
         self._drop_count += 1
@@ -263,13 +300,13 @@ class RoboCasaVLACameraPublisher:
             self._ready_event.set()
             while not self._stop_event.is_set():
                 try:
-                    timestamp, image = self._queue.get(timeout=0.1)
+                    timestamps, images = self._queue.get(timeout=0.1)
                 except queue.Empty:
                     continue
 
                 message = ImageMessageSchema(
-                    timestamps={self.config.output_key: timestamp},
-                    images={self.config.output_key: image},
+                    timestamps=timestamps,
+                    images=images,
                 )
                 server.send_message(message.serialize())
                 self._publish_count += 1

--- a/robocasa/utils/sonic_vla_streaming.py
+++ b/robocasa/utils/sonic_vla_streaming.py
@@ -20,6 +20,19 @@ import zmq
 
 MANAGER_HEADER_SIZE = 1280
 MANAGER_TOPIC = "manager_state"
+MANAGER_SESSION_FIELD = "manager_session_id"
+MANAGER_TIMESTAMP_FIELD = "manager_timestamp_monotonic"
+MANAGER_EVENT_SEQUENCE_FIELDS = {
+    "toggle_data_collection": "toggle_data_collection_sequence",
+    "toggle_data_abort": "toggle_data_abort_sequence",
+}
+MANAGER_EVENT_TIMESTAMP_FIELDS = {
+    "toggle_data_collection": "toggle_data_collection_event_monotonic",
+    "toggle_data_abort": "toggle_data_abort_event_monotonic",
+}
+EPISODE_INSTRUCTION_MESSAGE_TYPE = "robocasa_episode_instruction"
+EPISODE_INSTRUCTION_PROTOCOL_VERSION = 1
+EPISODE_INSTRUCTION_EVENTS = frozenset({"ready", "start"})
 
 
 def unpack_pico_message(packed_data: bytes, topic: str = MANAGER_TOPIC) -> dict[str, Any]:
@@ -78,20 +91,101 @@ def _array_bool(data: dict[str, Any], key: str) -> bool:
     return bool(value)
 
 
+def _array_scalar(data: dict[str, Any], key: str, cast):
+    value = data.get(key)
+    if value is None:
+        return None
+    if isinstance(value, np.ndarray):
+        if value.size == 0:
+            return None
+        value = value.flat[0]
+    try:
+        return cast(value)
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
 class ManagerStateSubscriber:
-    """Receive VR recording toggles from pico_manager_thread_server."""
+    """Receive the latest VR manager state without replaying stale samples.
+
+    Current manager publishers repeat monotonic event sequences in every state
+    message. This lets the SUB socket conflate continuous state while still
+    detecting a button edge that occurred while the simulator was rendering,
+    saving an episode, or resetting. Boolean toggles remain as a compatibility
+    fallback for older publishers.
+    """
 
     def __init__(self, host: str = "localhost", port: int = 5556):
+        self._subscribed_at_monotonic = time.monotonic()
         self._ctx = zmq.Context()
         self._socket = self._ctx.socket(zmq.SUB)
+        self._socket.setsockopt(zmq.CONFLATE, 1)
+        self._socket.setsockopt(zmq.RCVHWM, 1)
+        self._socket.setsockopt(zmq.LINGER, 0)
         self._socket.setsockopt_string(zmq.SUBSCRIBE, MANAGER_TOPIC)
-        self._socket.setsockopt(zmq.RCVHWM, 20)
         self._socket.setsockopt(zmq.RCVTIMEO, 0)
         self._socket.connect(f"tcp://{host}:{port}")
+        self._manager_session_id: int | None = None
+        self._last_event_sequences: dict[str, int] = {}
+        self.last_message_age_ms: float | None = None
+        self._last_latency_warning_time = 0.0
+
+    def _update_message_age(self, data: dict[str, Any]) -> None:
+        sent_at = _array_scalar(data, MANAGER_TIMESTAMP_FIELD, float)
+        if sent_at is None:
+            self.last_message_age_ms = None
+            return
+        self.last_message_age_ms = max(0.0, (time.monotonic() - sent_at) * 1000.0)
+        now = time.monotonic()
+        if self.last_message_age_ms > 250.0 and now - self._last_latency_warning_time >= 5.0:
+            print(
+                f"[sonic-vla] stale manager_state: {self.last_message_age_ms:.1f} ms old",
+                flush=True,
+            )
+            self._last_latency_warning_time = now
+
+    def _events_from_message(self, data: dict[str, Any]) -> set[str]:
+        events: set[str] = set()
+        session_id = _array_scalar(data, MANAGER_SESSION_FIELD, int)
+        session_changed = (
+            session_id is not None
+            and self._manager_session_id is not None
+            and session_id != self._manager_session_id
+        )
+        if session_id is not None:
+            self._manager_session_id = session_id
+
+        for event_name, sequence_field in MANAGER_EVENT_SEQUENCE_FIELDS.items():
+            sequence = _array_scalar(data, sequence_field, int)
+            pulse = _array_bool(data, event_name)
+            if sequence is None:
+                if pulse:
+                    events.add(event_name)
+                continue
+
+            previous = self._last_event_sequences.get(sequence_field)
+            if previous is None or session_changed:
+                # Establish a baseline without replaying events from before this
+                # subscriber connected. The repeated event timestamp covers an
+                # edge that happened after connect but whose pulse was conflated.
+                event_timestamp = _array_scalar(
+                    data, MANAGER_EVENT_TIMESTAMP_FIELDS[event_name], float
+                )
+                if pulse or (
+                    event_timestamp is not None
+                    and event_timestamp >= self._subscribed_at_monotonic
+                ):
+                    events.add(event_name)
+            elif sequence != previous:
+                events.add(event_name)
+            self._last_event_sequences[sequence_field] = sequence
+        return events
 
     def poll(self, max_messages: int = 20) -> set[str]:
         events: set[str] = set()
-        for _ in range(max_messages):
+        # CONFLATE guarantees at most one retained manager_state sample. Keep
+        # the argument for API compatibility with the previous subscriber.
+        for _ in range(min(max_messages, 1)):
             try:
                 raw = self._socket.recv(zmq.NOBLOCK)
             except zmq.Again:
@@ -100,10 +194,8 @@ class ManagerStateSubscriber:
                 data = unpack_pico_message(raw, topic=MANAGER_TOPIC)
             except Exception:
                 continue
-            if _array_bool(data, "toggle_data_collection"):
-                events.add("toggle_data_collection")
-            if _array_bool(data, "toggle_data_abort"):
-                events.add("toggle_data_abort")
+            self._update_message_age(data)
+            events.update(self._events_from_message(data))
         return events
 
     def close(self):
@@ -125,6 +217,129 @@ class VLAExporterKeyboardPublisher:
 
     def send(self, key: str):
         self._socket.send_string(key, flags=zmq.NOBLOCK)
+
+    def close(self):
+        self._socket.close()
+        self._ctx.term()
+
+
+def make_episode_instruction_message(
+    instruction: str | None,
+    *,
+    episode_id: str,
+    sequence: int,
+    event: str = "ready",
+    attempt: int = 0,
+    captured_at: float | None = None,
+) -> dict[str, Any]:
+    """Build the versioned metadata sent for one sampled RoboCasa episode."""
+    if not isinstance(episode_id, str) or not episode_id.strip():
+        raise ValueError("episode_id must be a non-empty string")
+    if isinstance(sequence, bool) or not isinstance(sequence, int) or sequence < 0:
+        raise ValueError("sequence must be a non-negative integer")
+    if event not in EPISODE_INSTRUCTION_EVENTS:
+        raise ValueError(f"event must be one of {sorted(EPISODE_INSTRUCTION_EVENTS)}")
+    if isinstance(attempt, bool) or not isinstance(attempt, int) or attempt < 0:
+        raise ValueError("attempt must be a non-negative integer")
+    if event == "ready" and attempt != 0:
+        raise ValueError("ready messages must use attempt 0")
+    if event == "start" and attempt == 0:
+        raise ValueError("start messages must use a positive attempt")
+    if instruction is not None:
+        if not isinstance(instruction, str):
+            raise TypeError("instruction must be a string or None")
+        instruction = instruction.strip() or None
+
+    return {
+        "type": EPISODE_INSTRUCTION_MESSAGE_TYPE,
+        "version": EPISODE_INSTRUCTION_PROTOCOL_VERSION,
+        "episode_id": episode_id.strip(),
+        "sequence": int(sequence),
+        "event": event,
+        "attempt": attempt,
+        "instruction": instruction,
+        "captured_at": time.time() if captured_at is None else float(captured_at),
+    }
+
+
+class VLAExporterInstructionPublisher:
+    """Publish the current episode instruction as replayable state.
+
+    This intentionally uses a separate port from the edge-triggered ``c`` / ``x``
+    keyboard channel. The latest instruction is repeated so an exporter started
+    after the RoboCasa collector still receives the current episode metadata.
+    """
+
+    def __init__(
+        self,
+        port: int = 5581,
+        *,
+        repeat_interval: float = 0.5,
+        startup_delay: float = 0.2,
+    ):
+        if repeat_interval <= 0:
+            raise ValueError("repeat_interval must be positive")
+        if startup_delay < 0:
+            raise ValueError("startup_delay must be non-negative")
+        self._ctx = zmq.Context()
+        self._socket = self._ctx.socket(zmq.PUB)
+        self._socket.setsockopt(zmq.SNDHWM, 20)
+        self._socket.setsockopt(zmq.LINGER, 0)
+        self._socket.bind(f"tcp://*:{port}")
+        self._repeat_interval = float(repeat_interval)
+        self._latest_message: dict[str, Any] | None = None
+        self._start_attempt = 0
+        self._last_publish_time = float("-inf")
+        if startup_delay:
+            time.sleep(startup_delay)
+
+    @property
+    def latest_message(self) -> dict[str, Any] | None:
+        if self._latest_message is None:
+            return None
+        return dict(self._latest_message)
+
+    def set_episode(
+        self,
+        instruction: str | None,
+        *,
+        episode_id: str,
+        sequence: int,
+    ) -> bool:
+        self._latest_message = make_episode_instruction_message(
+            instruction,
+            episode_id=episode_id,
+            sequence=sequence,
+        )
+        self._start_attempt = 0
+        return self.maybe_publish(force=True)
+
+    def mark_start(self) -> bool:
+        """Publish a new recording attempt tied to the current instruction."""
+        if self._latest_message is None:
+            raise RuntimeError("set_episode() must be called before mark_start()")
+        self._start_attempt += 1
+        self._latest_message = {
+            **self._latest_message,
+            "event": "start",
+            "attempt": self._start_attempt,
+        }
+        return self.maybe_publish(force=True)
+
+    def maybe_publish(self, *, force: bool = False) -> bool:
+        if self._latest_message is None:
+            return False
+        now = time.monotonic()
+        if not force and now - self._last_publish_time < self._repeat_interval:
+            return False
+
+        message = {**self._latest_message, "sent_at": time.time()}
+        try:
+            self._socket.send_json(message, flags=zmq.NOBLOCK)
+        except zmq.Again:
+            return False
+        self._last_publish_time = now
+        return True
 
     def close(self):
         self._socket.close()
@@ -240,7 +455,10 @@ class RoboCasaVLACameraPublisher:
         return True
 
     def _render_images(self, env) -> dict[str, np.ndarray]:
+        previous_renderer = self._renderer
+        render_started = time.perf_counter()
         renderer, scene_option = self._get_live_renderer(env)
+        rebuilding_renderer = renderer is not previous_renderer
         images: dict[str, np.ndarray] = {}
         for camera_name, output_key in zip(self._camera_names, self._output_keys):
             renderer.update_scene(
@@ -248,6 +466,12 @@ class RoboCasaVLACameraPublisher:
             )
             image = renderer.render()
             images[output_key] = _prepare_image(image, self.config.flip_vertical)
+        if rebuilding_renderer:
+            print(
+                f"[sonic-timing] initialized {len(self._camera_names)}-camera renderer "
+                f"in {time.perf_counter() - render_started:.3f}s",
+                flush=True,
+            )
         return images
 
     def _raise_sender_error(self):

--- a/tests/test_boil_corn.py
+++ b/tests/test_boil_corn.py
@@ -1,0 +1,98 @@
+from types import SimpleNamespace
+
+import pytest
+
+from robocasa.environments.kitchen.composite.boiling import boil_corn as task_module
+from robocasa.environments.kitchen.composite.boiling.boil_corn import BoilCorn
+
+
+def _bare_task():
+    task = object.__new__(BoilCorn)
+    task.knob = "front_left"
+    task.stove = SimpleNamespace()
+    return task
+
+
+def _install_success_state(monkeypatch, task, state, calls):
+    def check_saucepan_location(env, obj_name, threshold):
+        calls["saucepan"] = (obj_name, threshold)
+        return state.burner_location
+
+    def check_receptacle(env, obj_name, receptacle_name, th=None):
+        calls[obj_name] = (receptacle_name, th)
+        return state.in_receptacle[obj_name]
+
+    task.stove.check_obj_location_on_stove = check_saucepan_location
+    monkeypatch.setattr(task_module.OU, "check_obj_in_receptacle", check_receptacle)
+    monkeypatch.setattr(
+        task_module.OU,
+        "gripper_obj_far",
+        lambda env, obj_name: state.gripper_far,
+    )
+
+
+def test_boil_corn_uses_relaxed_local_thresholds(monkeypatch):
+    task = _bare_task()
+    calls = {}
+    state = SimpleNamespace(
+        burner_location=task.knob,
+        in_receptacle={
+            "corn1": True,
+            "corn2": True,
+            "saucepan_auxiliary": True,
+        },
+        gripper_far=True,
+    )
+    _install_success_state(monkeypatch, task, state, calls)
+
+    assert task._check_success()
+    assert calls["saucepan"] == (
+        "saucepan",
+        BoilCorn.SAUCEPAN_BURNER_THRESHOLD,
+    )
+    assert BoilCorn.SAUCEPAN_BURNER_THRESHOLD == 0.15
+    assert calls["saucepan_auxiliary"] == (
+        "saucepan",
+        BoilCorn.LID_ON_SAUCEPAN_THRESHOLD,
+    )
+    assert BoilCorn.LID_ON_SAUCEPAN_THRESHOLD == 0.05
+    assert calls["corn1"] == ("saucepan", None)
+    assert calls["corn2"] == ("saucepan", None)
+
+
+@pytest.mark.parametrize(
+    ("failed_condition", "value"),
+    [
+        ("burner_location", None),
+        ("burner_location", "front_right"),
+        ("corn1", False),
+        ("corn2", False),
+        ("lid", False),
+        ("gripper_far", False),
+    ],
+)
+def test_boil_corn_still_requires_every_semantic_condition(
+    monkeypatch, failed_condition, value
+):
+    task = _bare_task()
+    calls = {}
+    state = SimpleNamespace(
+        burner_location=task.knob,
+        in_receptacle={
+            "corn1": True,
+            "corn2": True,
+            "saucepan_auxiliary": True,
+        },
+        gripper_far=True,
+    )
+    if failed_condition == "burner_location":
+        state.burner_location = value
+    elif failed_condition == "lid":
+        state.in_receptacle["saucepan_auxiliary"] = value
+    elif failed_condition in ("corn1", "corn2"):
+        state.in_receptacle[failed_condition] = value
+    else:
+        state.gripper_far = value
+    _install_success_state(monkeypatch, task, state, calls)
+
+    assert not task._check_success()

--- a/tests/test_collect_sonic_render_camera.py
+++ b/tests/test_collect_sonic_render_camera.py
@@ -1,0 +1,47 @@
+import sys
+from types import SimpleNamespace
+
+from robocasa.scripts import collect_sonic_demos as collector
+
+
+def _parse_args(monkeypatch, *args):
+    monkeypatch.setattr(sys, "argv", ["collect_sonic_demos.py", *args])
+    return collector.get_args()
+
+
+def test_render_camera_defaults_to_frontview(monkeypatch):
+    args = _parse_args(monkeypatch)
+
+    assert args.render_camera == "robot0_frontview"
+
+
+def test_render_camera_accepts_robot_head_camera(monkeypatch):
+    args = _parse_args(monkeypatch, "--render-camera", "robot0_head_camera")
+
+    assert args.render_camera == "robot0_head_camera"
+
+
+def test_make_env_forwards_render_camera(monkeypatch):
+    captured = {}
+    fake_env = object()
+
+    def fake_make(environment, **kwargs):
+        captured["environment"] = environment
+        captured.update(kwargs)
+        return fake_env
+
+    monkeypatch.setattr(collector.robosuite, "make", fake_make)
+    args = SimpleNamespace(
+        environment="Kitchen",
+        robot="SonicG1",
+        layout=1,
+        style=None,
+        control_freq=200,
+        render_camera="robot0_head_camera",
+    )
+
+    env, _ = collector.make_env(args, cfg={})
+
+    assert env is fake_env
+    assert captured["render_camera"] == "robot0_head_camera"
+    assert captured["initialization_noise"] is None

--- a/tests/test_collect_sonic_render_camera.py
+++ b/tests/test_collect_sonic_render_camera.py
@@ -15,6 +15,12 @@ def test_render_camera_defaults_to_frontview(monkeypatch):
     assert args.render_camera == "robot0_frontview"
 
 
+def test_layout_defaults_to_random_test_group(monkeypatch):
+    args = _parse_args(monkeypatch)
+
+    assert args.layout == -1
+
+
 def test_render_camera_accepts_robot_head_camera(monkeypatch):
     args = _parse_args(monkeypatch, "--render-camera", "robot0_head_camera")
 

--- a/tests/test_collect_sonic_reset.py
+++ b/tests/test_collect_sonic_reset.py
@@ -1,7 +1,79 @@
 import json
 from types import SimpleNamespace
 
+import numpy as np
+
 from robocasa.scripts import collect_sonic_demos as collector
+
+
+def test_episode_event_priority_matches_exporter_abort_first():
+    assert collector._resolve_episode_event(
+        {"c"}, {"toggle_data_abort"}, recording=False
+    ) == (None, True)
+    assert collector._resolve_episode_event(
+        {"k"}, {"toggle_data_abort"}, recording=True
+    ) == ("discard", True)
+    assert collector._resolve_episode_event(
+        {"x"}, {"toggle_data_collection"}, recording=True
+    ) == ("discard", False)
+    assert collector._resolve_episode_event(
+        set(), {"toggle_data_collection"}, recording=True
+    ) == ("save", True)
+
+
+def test_instruction_snapshot_is_single_read_and_frozen(capsys):
+    calls = []
+
+    class FakeBase:
+        def get_ep_meta(self):
+            calls.append("get")
+            return {"lang": "Pick up the cup and bowl."}
+
+        def set_ep_meta(self, metadata):
+            calls.append(("set", metadata.copy()))
+
+    metadata, instruction = collector._snapshot_and_print_instruction(FakeBase())
+
+    assert metadata == {"lang": "Pick up the cup and bowl."}
+    assert instruction == "Pick up the cup and bowl."
+    assert calls == ["get", ("set", metadata)]
+    assert "Instruction: Pick up the cup and bowl." in capsys.readouterr().out
+
+
+def test_collection_wrapper_reuses_forwarded_episode_metadata(monkeypatch, tmp_path):
+    expected_metadata = {"lang": "sampled instruction", "layout_id": 1}
+    set_calls = []
+
+    class FakeState:
+        def flatten(self):
+            return [1.0, 2.0]
+
+    class FakeEnv:
+        model = SimpleNamespace(get_xml=lambda: "<mujoco />")
+        sim = SimpleNamespace(get_state=lambda: FakeState())
+
+        def get_ep_meta(self):
+            raise AssertionError("episode metadata must not be sampled twice")
+
+        def set_ep_meta(self, metadata):
+            set_calls.append(metadata)
+
+    wrapper = object.__new__(collector.SonicDataCollectionWrapper)
+    wrapper.env = FakeEnv()
+    wrapper.directory = str(tmp_path)
+    wrapper.has_interaction = False
+    wrapper.states = []
+    wrapper.integration_states = []
+    wrapper.action_infos = []
+    monkeypatch.setattr(wrapper, "_integration_state_for", lambda env: np.array([3.0]))
+
+    wrapper.start_episode_from_current_state(ep_meta=expected_metadata)
+    wrapper._on_first_interaction()
+
+    assert set_calls == [expected_metadata]
+    assert wrapper._current_task_instance_xml == "<mujoco />"
+    with open(f"{wrapper.ep_directory}/ep_meta.json", encoding="utf-8") as stream:
+        assert json.load(stream) == expected_metadata
 
 
 def test_make_env_configures_and_records_pgs_solver(monkeypatch):

--- a/tests/test_collect_sonic_reset.py
+++ b/tests/test_collect_sonic_reset.py
@@ -1,6 +1,40 @@
+import json
 from types import SimpleNamespace
 
 from robocasa.scripts import collect_sonic_demos as collector
+
+
+def test_make_env_configures_and_records_pgs_solver(monkeypatch):
+    captured = {}
+    fake_env = object()
+
+    def fake_make(environment, **kwargs):
+        captured["environment"] = environment
+        captured.update(kwargs)
+        return fake_env
+
+    monkeypatch.setattr(collector.robosuite, "make", fake_make)
+    args = SimpleNamespace(
+        environment="CloseDishwasher",
+        robot="SonicG1",
+        render_camera="robot0_head_camera",
+        layout=1,
+        style=1,
+        control_freq=200,
+        sim_dt=0.005,
+        post_action_hz=20.0,
+        render_hz=20.0,
+        floor_friction=1.0,
+        floor_torsion=0.005,
+    )
+
+    env, env_kwargs = collector.make_env(args, cfg={"type": "SONIC_WBC"})
+
+    assert env is fake_env
+    assert captured["mujoco_solver"] == "PGS"
+    assert env_kwargs["mujoco_solver"] == "PGS"
+    assert json.loads(json.dumps(env_kwargs))["mujoco_solver"] == "PGS"
+    assert json.loads(collector._sonic_runtime_json(args))["mujoco_solver"] == "PGS"
 
 
 def test_reset_with_retry_clears_episode_metadata_before_reset(monkeypatch):

--- a/tests/test_collect_sonic_reset.py
+++ b/tests/test_collect_sonic_reset.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+
+from robocasa.scripts import collect_sonic_demos as collector
+
+
+def test_reset_with_retry_clears_episode_metadata_before_reset(monkeypatch):
+    events = []
+    observation = {"state": "reset"}
+
+    class FakeEnvironment:
+        def reset(self):
+            events.append("reset")
+            return observation
+
+    class FakeBase:
+        def unset_ep_meta(self):
+            events.append("unset_ep_meta")
+
+    monkeypatch.setattr(
+        collector,
+        "_apply_runtime",
+        lambda base, args: events.append("apply_runtime"),
+    )
+
+    result = collector.reset_with_retry(
+        FakeEnvironment(),
+        FakeBase(),
+        SimpleNamespace(),
+    )
+
+    assert result is observation
+    assert events == ["unset_ep_meta", "reset", "apply_runtime"]
+
+
+def test_reset_with_retry_clears_episode_metadata_before_every_attempt(monkeypatch):
+    events = []
+    observation = {"state": "reset"}
+    reset_attempts = 0
+
+    class FakeEnvironment:
+        def reset(self):
+            nonlocal reset_attempts
+            reset_attempts += 1
+            events.append("reset")
+            if reset_attempts == 1:
+                raise collector.mujoco.FatalError("rank-deficient Hessian")
+            return observation
+
+    class FakeBase:
+        def unset_ep_meta(self):
+            events.append("unset_ep_meta")
+
+    monkeypatch.setattr(
+        collector,
+        "_apply_runtime",
+        lambda base, args: events.append("apply_runtime"),
+    )
+
+    result = collector.reset_with_retry(
+        FakeEnvironment(),
+        FakeBase(),
+        SimpleNamespace(),
+        tries=2,
+    )
+
+    assert result is observation
+    assert events == [
+        "unset_ep_meta",
+        "reset",
+        "unset_ep_meta",
+        "reset",
+        "apply_runtime",
+    ]

--- a/tests/test_drawer_cake_sort.py
+++ b/tests/test_drawer_cake_sort.py
@@ -1,0 +1,85 @@
+from types import SimpleNamespace
+
+from robocasa.environments.kitchen.composite.tidying_cabinets_and_drawers import (
+    drawer_cake_sort as task_module,
+)
+from robocasa.environments.kitchen.composite.tidying_cabinets_and_drawers.drawer_cake_sort import (
+    DrawerCakeSort,
+)
+
+
+def _bare_task():
+    task = object.__new__(DrawerCakeSort)
+    task.counter = object()
+    task.drawer = SimpleNamespace(is_closed=lambda env: True)
+    return task
+
+
+def test_drawer_cake_sort_uses_two_cakes_without_lateral_offsets():
+    task = _bare_task()
+
+    configs = task._get_obj_cfgs()
+
+    assert [config["name"] for config in configs] == ["cake1", "cake2"]
+    assert [config["obj_groups"] for config in configs] == ["cake", "cake"]
+    assert all("offset" not in config["placement"] for config in configs)
+    assert all(
+        config["placement"]["pos"] == ("ref", -1.0) for config in configs
+    )
+    assert [config["placement"]["size"][1] for config in configs] == [0.15, 0.15]
+
+
+def test_drawer_cake_sort_instruction_describes_goal_without_placement_details(
+    monkeypatch,
+):
+    task = _bare_task()
+    monkeypatch.setattr(
+        task_module.ManipulateDrawer,
+        "get_ep_meta",
+        lambda self: {"lang": "Open the left drawer."},
+    )
+
+    assert task.get_ep_meta()["lang"] == (
+        "Open the drawer, place both cakes inside it, then close the drawer."
+    )
+
+
+def test_drawer_cake_sort_success_requires_cakes_stored_released_and_drawer_closed(
+    monkeypatch,
+):
+    task = _bare_task()
+    state = SimpleNamespace(
+        inside={"cake1": True, "cake2": True},
+        counter_contact={"cake1": False, "cake2": False},
+        gripper_far={"cake1": True, "cake2": True},
+        drawer_closed=True,
+    )
+    task.drawer.is_closed = lambda env: state.drawer_closed
+    monkeypatch.setattr(
+        task_module.OU,
+        "obj_inside_of",
+        lambda env, name, drawer: state.inside[name],
+    )
+    monkeypatch.setattr(
+        task_module.OU,
+        "check_obj_any_counter_contact",
+        lambda env, name: state.counter_contact[name],
+    )
+    monkeypatch.setattr(
+        task_module.OU,
+        "gripper_obj_far",
+        lambda env, obj_name: state.gripper_far[obj_name],
+    )
+
+    assert task._check_success()
+
+    state.counter_contact["cake2"] = True
+    assert not task._check_success()
+
+    state.counter_contact["cake2"] = False
+    state.gripper_far["cake1"] = False
+    assert not task._check_success()
+
+    state.gripper_far["cake1"] = True
+    state.drawer_closed = False
+    assert not task._check_success()

--- a/tests/test_object_utils_grasp.py
+++ b/tests/test_object_utils_grasp.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from robocasa.utils.object_utils import check_obj_grasped
+
+
+class _Model:
+    def __init__(self, joint_addresses):
+        self._joint_addresses = joint_addresses
+
+    def get_joint_qpos_addr(self, joint):
+        if joint not in self._joint_addresses:
+            raise ValueError(f'No "joint" with name {joint} exists.')
+        return self._joint_addresses[joint]
+
+
+def _env(*, joints, qpos, contact):
+    gripper = SimpleNamespace(joints=joints)
+    env = SimpleNamespace(
+        objects={"sponge": object()},
+        robots=[SimpleNamespace(gripper={"right": gripper})],
+        sim=SimpleNamespace(
+            model=_Model(
+                {
+                    "gripper0_right_finger_joint1": 0,
+                    "gripper0_right_finger_joint2": 1,
+                }
+            ),
+            data=SimpleNamespace(qpos=np.asarray(qpos, dtype=float)),
+        ),
+    )
+    env.check_contact = lambda actual_gripper, actual_obj: (
+        actual_gripper is gripper
+        and actual_obj is env.objects["sponge"]
+        and contact
+    )
+    return env
+
+
+@pytest.mark.parametrize(
+    ("qpos", "expected"),
+    [
+        ((0.02, -0.02), True),
+        ((0.04, -0.04), False),
+    ],
+)
+def test_check_obj_grasped_preserves_two_finger_closure_check(qpos, expected):
+    env = _env(
+        joints=(
+            "gripper0_right_finger_joint1",
+            "gripper0_right_finger_joint2",
+        ),
+        qpos=qpos,
+        contact=True,
+    )
+
+    assert check_obj_grasped(env, "sponge") is expected
+
+
+@pytest.mark.parametrize("contact", [False, True])
+def test_check_obj_grasped_uses_contact_for_sonic_dex3(contact):
+    env = _env(
+        joints=(
+            "gripper0_right_right_hand_thumb_0_joint",
+            "gripper0_right_right_hand_middle_0_joint",
+            "gripper0_right_right_hand_index_0_joint",
+        ),
+        qpos=(0.0, 0.0),
+        contact=contact,
+    )
+
+    assert check_obj_grasped(env, "sponge", threshold=0.6) is contact

--- a/tests/test_pick_place_counter_to_stove_placement.py
+++ b/tests/test_pick_place_counter_to_stove_placement.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+
+import pytest
+
+from robocasa.environments.kitchen.atomic.kitchen_pick_place import (
+    PickPlaceCounterToStove,
+)
+from robocasa.utils import env_utils as EnvUtils
+
+
+def _make_task(robot_name):
+    robot_model_cls = type(robot_name, (), {})
+    task = object.__new__(PickPlaceCounterToStove)
+    task.robots = [SimpleNamespace(robot_model=robot_model_cls())]
+    task.obj_groups = "food"
+    task.exclude_obj_groups = None
+    task.stove = object()
+    task.counter = object()
+    task._ep_meta = {}
+    task.model = SimpleNamespace(merge_objects=lambda _: None)
+    return task
+
+
+def _food_placement(task):
+    return next(
+        cfg["placement"] for cfg in task._get_obj_cfgs() if cfg["name"] == "obj"
+    )
+
+
+def test_sonic_g1_restricts_only_generated_plate_to_counter_front():
+    task = _make_task("SonicG1")
+    food_placement = _food_placement(task)
+
+    assert food_placement["size"] == (0.30, 0.30)
+    assert "side" not in food_placement
+    plate_placement = food_placement["try_to_place_in_kwargs"]["placement"]
+    assert plate_placement["fixture"] is task.counter
+    assert plate_placement["sample_region_kwargs"]["ref"] is task.stove
+    assert plate_placement["size"] == (0.30, 0.30)
+    assert plate_placement["pos"] == ("ref", -1.0)
+    assert plate_placement["side"] == "front"
+    assert "rotation" not in plate_placement
+
+
+@pytest.mark.parametrize("robot_name", ["PandaOmron", "G1", "SonicG1Fixed"])
+def test_other_robots_keep_original_plate_sampling(robot_name):
+    placement = _food_placement(_make_task(robot_name))
+
+    assert placement["size"] == (0.30, 0.30)
+    assert placement["pos"] == ("ref", -1.0)
+    assert "try_to_place_in_kwargs" not in placement
+
+
+def test_sonic_plate_override_reaches_generated_container(monkeypatch):
+    task = _make_task("SonicG1")
+
+    def fake_create_obj(_env, cfg):
+        groups = ["in_container"] if cfg["name"] == "obj" else []
+        return SimpleNamespace(name=cfg["name"]), {
+            "groups_containing_sampled_obj": groups
+        }
+
+    monkeypatch.setattr(EnvUtils, "create_obj", fake_create_obj)
+    task._create_objects()
+
+    plate_cfg = next(c for c in task.object_cfgs if c["name"] == "obj_container")
+    food_cfg = next(c for c in task.object_cfgs if c["name"] == "obj")
+    assert plate_cfg["placement"]["side"] == "front"
+    assert "rotation" not in plate_cfg["placement"]
+    assert food_cfg["placement"]["sample_args"]["reference"] == "obj_container"

--- a/tests/test_placement_sampler_sides.py
+++ b/tests/test_placement_sampler_sides.py
@@ -1,0 +1,49 @@
+import pytest
+
+from robocasa.utils.placement_samplers import UniformRandomSampler
+
+
+class MidpointRng:
+    def __init__(self):
+        self.bounds = None
+
+    def uniform(self, *, high, low):
+        self.bounds = (low, high)
+        return (low + high) / 2
+
+
+@pytest.mark.parametrize(
+    ("side", "axis", "expected_bounds"),
+    [
+        ("all", "x", (0.1, 0.9)),
+        ("all", "y", (0.1, 0.9)),
+        ("left", "x", (0.1, 0.5)),
+        ("right", "x", (0.5, 0.9)),
+        ("front", "y", (0.1, 0.5)),
+        ("back", "y", (0.5, 0.9)),
+        ("front_left", "x", (0.1, 0.5)),
+        ("front_left", "y", (0.1, 0.5)),
+        ("back_right", "x", (0.5, 0.9)),
+        ("back_right", "y", (0.5, 0.9)),
+    ],
+)
+def test_uniform_sampler_restricts_valid_center_range_by_side(
+    side, axis, expected_bounds
+):
+    rng = MidpointRng()
+    sampler = UniformRandomSampler(
+        name="test",
+        x_range=(0.0, 1.0),
+        y_range=(0.0, 1.0),
+        side=side,
+        rng=rng,
+    )
+
+    getattr(sampler, f"_sample_{axis}")((0.2, 0.2, 0.1))
+
+    assert rng.bounds == expected_bounds
+
+
+def test_uniform_sampler_rejects_unknown_side():
+    with pytest.raises(ValueError, match="Invalid value for side"):
+        UniformRandomSampler(name="test", side="near_wall")

--- a/tests/test_slide_dishwasher_rack_robot_init_offset.py
+++ b/tests/test_slide_dishwasher_rack_robot_init_offset.py
@@ -1,0 +1,109 @@
+import xml.etree.ElementTree as ET
+
+import numpy as np
+
+import robocasa  # noqa: F401  Registers RoboCasa environments with robosuite.
+import robosuite
+from robosuite.controllers import load_composite_controller_config
+from robosuite.scripts.collect_sonic_g1_demos import SONIC_CFG
+
+from robocasa.utils.env_utils import compute_robot_base_placement_pose
+
+
+LEFT_OFFSET_METERS = 0.50
+
+
+def _make_env():
+    return robosuite.make(
+        "SlideDishwasherRack",
+        robots=["SonicG1"],
+        controller_configs=load_composite_controller_config(
+            controller=SONIC_CFG,
+            robot="SonicG1",
+        ),
+        has_renderer=False,
+        has_offscreen_renderer=False,
+        use_camera_obs=False,
+        ignore_done=True,
+        layout_ids=1,
+        style_ids=1,
+        control_freq=200,
+        initialization_noise=None,
+        seed=7,
+    )
+
+
+def _xml_pelvis_position(env):
+    root = ET.fromstring(env.model.get_xml())
+    pelvis = next(
+        body for body in root.iter("body") if body.get("name") == "robot0_pelvis"
+    )
+    return np.fromstring(pelvis.attrib["pos"], sep=" ")
+
+
+def test_slide_dishwasher_rack_applies_default_left_offset_to_sonic_root():
+    env = None
+    try:
+        env = _make_env()
+        env.reset()
+
+        unshifted_anchor, base_ori = compute_robot_base_placement_pose(
+            env,
+            ref_fixture=env.dishwasher,
+        )
+        yaw = base_ori[2]
+        expected_delta = LEFT_OFFSET_METERS * np.array([-np.sin(yaw), np.cos(yaw), 0.0])
+
+        np.testing.assert_allclose(
+            env.init_robot_base_pos_anchor - unshifted_anchor,
+            expected_delta,
+            atol=1e-7,
+        )
+        assert env.robot_init_offset == (-LEFT_OFFSET_METERS, 0.0)
+        np.testing.assert_allclose(
+            env.get_ep_meta()["init_robot_base_pos"],
+            env.init_robot_base_pos,
+            atol=1e-7,
+        )
+        np.testing.assert_allclose(
+            _xml_pelvis_position(env),
+            env.init_robot_base_pos_anchor,
+            atol=1e-7,
+        )
+
+        env.step(np.zeros(env.action_spec[0].shape))
+        assert np.isfinite(env.sim.data.qpos).all()
+        assert np.isfinite(env.sim.data.ctrl).all()
+    finally:
+        if env is not None:
+            env.close()
+
+
+def test_slide_dishwasher_rack_replays_with_the_fixed_default_left_offset():
+    source = restored = None
+    try:
+        source = _make_env()
+        source.reset()
+        metadata = source.get_ep_meta()
+
+        assert metadata["robot_init_offset"] == [-LEFT_OFFSET_METERS, 0.0]
+
+        restored = _make_env()
+        restored.set_ep_meta(metadata)
+        restored.reset()
+
+        np.testing.assert_allclose(
+            restored.init_robot_base_pos_anchor,
+            source.init_robot_base_pos_anchor,
+            atol=1e-7,
+        )
+        np.testing.assert_allclose(
+            _xml_pelvis_position(restored),
+            restored.init_robot_base_pos_anchor,
+            atol=1e-7,
+        )
+    finally:
+        if source is not None:
+            source.close()
+        if restored is not None:
+            restored.close()

--- a/tests/test_sonic_vla_streaming.py
+++ b/tests/test_sonic_vla_streaming.py
@@ -8,11 +8,15 @@ import pytest
 import zmq
 
 from robocasa.utils.sonic_vla_streaming import (
+    EPISODE_INSTRUCTION_MESSAGE_TYPE,
+    EPISODE_INSTRUCTION_PROTOCOL_VERSION,
     MANAGER_HEADER_SIZE,
     ManagerStateSubscriber,
     RoboCasaVLACameraPublisher,
     VLACameraConfig,
+    VLAExporterInstructionPublisher,
     VLAExporterKeyboardPublisher,
+    make_episode_instruction_message,
 )
 
 
@@ -24,21 +28,66 @@ def _free_port():
     return port
 
 
-def _pack_manager_state(toggle=False, abort=False, stream_mode=1):
+def _pack_manager_state(
+    toggle=False,
+    abort=False,
+    stream_mode=1,
+    toggle_sequence=None,
+    abort_sequence=None,
+    session_id=123,
+    timestamp_monotonic=None,
+    toggle_event_monotonic=0.0,
+    abort_event_monotonic=0.0,
+):
     fields = [
         {"name": "stream_mode", "dtype": "i32", "shape": [1]},
         {"name": "toggle_data_collection", "dtype": "bool", "shape": [1]},
         {"name": "toggle_data_abort", "dtype": "bool", "shape": [1]},
     ]
+    arrays = [
+        np.array([stream_mode], dtype=np.int32),
+        np.array([toggle], dtype=bool),
+        np.array([abort], dtype=bool),
+    ]
+    if toggle_sequence is not None and abort_sequence is not None:
+        fields.extend(
+            [
+                {"name": "manager_session_id", "dtype": "i64", "shape": [1]},
+                {
+                    "name": "toggle_data_collection_sequence",
+                    "dtype": "i64",
+                    "shape": [1],
+                },
+                {"name": "toggle_data_abort_sequence", "dtype": "i64", "shape": [1]},
+                {
+                    "name": "toggle_data_collection_event_monotonic",
+                    "dtype": "f64",
+                    "shape": [1],
+                },
+                {
+                    "name": "toggle_data_abort_event_monotonic",
+                    "dtype": "f64",
+                    "shape": [1],
+                },
+                {"name": "manager_timestamp_monotonic", "dtype": "f64", "shape": [1]},
+            ]
+        )
+        arrays.extend(
+            [
+                np.array([session_id], dtype=np.int64),
+                np.array([toggle_sequence], dtype=np.int64),
+                np.array([abort_sequence], dtype=np.int64),
+                np.array([toggle_event_monotonic], dtype=np.float64),
+                np.array([abort_event_monotonic], dtype=np.float64),
+                np.array(
+                    [time.monotonic() if timestamp_monotonic is None else timestamp_monotonic],
+                    dtype=np.float64,
+                ),
+            ]
+        )
     header = json.dumps({"v": 3, "endian": "le", "count": 1, "fields": fields}).encode("utf-8")
     header = header.ljust(MANAGER_HEADER_SIZE, b"\x00")
-    payload = b"".join(
-        [
-            np.array([stream_mode], dtype=np.int32).tobytes(),
-            np.array([toggle], dtype=bool).tobytes(),
-            np.array([abort], dtype=bool).tobytes(),
-        ]
-    )
+    payload = b"".join(array.tobytes() for array in arrays)
     return b"manager_state" + header + payload
 
 
@@ -52,8 +101,11 @@ def test_manager_state_subscriber_receives_mock_vr_toggles():
         time.sleep(0.2)
         deadline = time.time() + 2.0
         events = set()
-        while time.time() < deadline and not {"toggle_data_collection", "toggle_data_abort"} <= events:
+        while time.time() < deadline and "toggle_data_collection" not in events:
             pub.send(_pack_manager_state(toggle=True, abort=False))
+            time.sleep(0.02)
+            events |= sub.poll()
+        while time.time() < deadline and "toggle_data_abort" not in events:
             pub.send(_pack_manager_state(toggle=False, abort=True))
             time.sleep(0.02)
             events |= sub.poll()
@@ -64,6 +116,95 @@ def test_manager_state_subscriber_receives_mock_vr_toggles():
         sub.close()
         pub.close()
         ctx.term()
+
+
+def test_manager_state_subscriber_recovers_conflated_sequence_events():
+    ctx = zmq.Context()
+    pub = ctx.socket(zmq.PUB)
+    port = pub.bind_to_random_port("tcp://127.0.0.1")
+    sub = ManagerStateSubscriber(host="127.0.0.1", port=port)
+
+    try:
+        time.sleep(0.2)
+        deadline = time.time() + 2.0
+        while time.time() < deadline and sub.last_message_age_ms is None:
+            pub.send(_pack_manager_state(toggle_sequence=0, abort_sequence=0))
+            time.sleep(0.02)
+            assert sub.poll() == set()
+        assert sub.last_message_age_ms is not None
+
+        # Both one-frame pulses occur while the subscriber is not polling. The
+        # final conflated sample retains their cumulative sequence numbers.
+        pub.send(
+            _pack_manager_state(
+                toggle=True,
+                toggle_sequence=1,
+                abort_sequence=0,
+            )
+        )
+        pub.send(
+            _pack_manager_state(
+                abort=True,
+                toggle_sequence=1,
+                abort_sequence=1,
+            )
+        )
+        pub.send(_pack_manager_state(toggle_sequence=1, abort_sequence=1))
+        time.sleep(0.05)
+
+        assert sub.poll() == {"toggle_data_collection", "toggle_data_abort"}
+
+        pub.send(_pack_manager_state(toggle_sequence=1, abort_sequence=1))
+        time.sleep(0.02)
+        assert sub.poll() == set()
+        assert sub.last_message_age_ms is not None
+        assert sub.last_message_age_ms < 250.0
+    finally:
+        sub.close()
+        pub.close()
+        ctx.term()
+
+
+def test_manager_state_subscriber_does_not_replay_previous_manager_session():
+    sub = ManagerStateSubscriber.__new__(ManagerStateSubscriber)
+    sub._subscribed_at_monotonic = time.monotonic()
+    sub._manager_session_id = None
+    sub._last_event_sequences = {}
+
+    old_session = {
+        "manager_session_id": np.array([10], dtype=np.int64),
+        "toggle_data_collection_sequence": np.array([7], dtype=np.int64),
+        "toggle_data_abort_sequence": np.array([3], dtype=np.int64),
+    }
+    assert sub._events_from_message(old_session) == set()
+
+    new_session = {
+        "manager_session_id": np.array([11], dtype=np.int64),
+        "toggle_data_collection_sequence": np.array([0], dtype=np.int64),
+        "toggle_data_abort_sequence": np.array([0], dtype=np.int64),
+    }
+    assert sub._events_from_message(new_session) == set()
+
+
+def test_manager_state_subscriber_recovers_first_event_after_connect():
+    sub = ManagerStateSubscriber.__new__(ManagerStateSubscriber)
+    sub._subscribed_at_monotonic = time.monotonic()
+    sub._manager_session_id = None
+    sub._last_event_sequences = {}
+
+    first_sample = {
+        "manager_session_id": np.array([20], dtype=np.int64),
+        "toggle_data_collection": np.array([False], dtype=bool),
+        "toggle_data_abort": np.array([False], dtype=bool),
+        "toggle_data_collection_sequence": np.array([1], dtype=np.int64),
+        "toggle_data_abort_sequence": np.array([0], dtype=np.int64),
+        "toggle_data_collection_event_monotonic": np.array(
+            [sub._subscribed_at_monotonic + 0.01], dtype=np.float64
+        ),
+        "toggle_data_abort_event_monotonic": np.array([0.0], dtype=np.float64),
+    }
+
+    assert sub._events_from_message(first_sample) == {"toggle_data_collection"}
 
 
 def test_vla_keyboard_publisher_sends_exporter_keys():
@@ -83,6 +224,82 @@ def test_vla_keyboard_publisher_sends_exporter_keys():
         sub.close()
         ctx.term()
         pub.close()
+
+
+def test_episode_instruction_message_preserves_sampled_prompt():
+    message = make_episode_instruction_message(
+        "  Pick up the cup and bowl: then close the dishwasher.  ",
+        episode_id="session:000003",
+        sequence=3,
+        captured_at=123.5,
+    )
+
+    assert message == {
+        "type": EPISODE_INSTRUCTION_MESSAGE_TYPE,
+        "version": EPISODE_INSTRUCTION_PROTOCOL_VERSION,
+        "episode_id": "session:000003",
+        "sequence": 3,
+        "event": "ready",
+        "attempt": 0,
+        "instruction": "Pick up the cup and bowl: then close the dishwasher.",
+        "captured_at": 123.5,
+    }
+
+
+def test_vla_instruction_publisher_repeats_latest_episode_state():
+    port = _free_port()
+    pub = VLAExporterInstructionPublisher(
+        port=port,
+        repeat_interval=0.01,
+        startup_delay=0.0,
+    )
+    ctx = zmq.Context()
+    sub = ctx.socket(zmq.SUB)
+    sub.setsockopt_string(zmq.SUBSCRIBE, "")
+    sub.connect(f"tcp://127.0.0.1:{port}")
+
+    try:
+        time.sleep(0.2)
+        assert pub.set_episode(
+            "Pick up the cup and bowl.",
+            episode_id="session:000000",
+            sequence=0,
+        )
+        assert sub.poll(1000)
+        first = sub.recv_json()
+        assert first["instruction"] == "Pick up the cup and bowl."
+        assert first["episode_id"] == "session:000000"
+        assert first["event"] == "ready"
+        assert first["attempt"] == 0
+
+        assert pub.mark_start()
+        assert sub.poll(1000)
+        started = sub.recv_json()
+        assert started["event"] == "start"
+        assert started["attempt"] == 1
+        assert started["captured_at"] == first["captured_at"]
+
+        time.sleep(0.02)
+        assert pub.maybe_publish()
+        assert sub.poll(1000)
+        repeated = sub.recv_json()
+        assert repeated["event"] == "start"
+        assert repeated["attempt"] == 1
+        assert repeated["sent_at"] >= started["sent_at"]
+    finally:
+        sub.close()
+        ctx.term()
+        pub.close()
+
+
+def test_vla_instruction_publisher_marks_missing_prompt_for_cli_fallback():
+    message = make_episode_instruction_message(
+        "   ",
+        episode_id="session:000004",
+        sequence=4,
+    )
+
+    assert message["instruction"] is None
 
 
 def test_vla_camera_config_defaults_to_sonic_ego_view():

--- a/tests/test_sonic_vla_streaming.py
+++ b/tests/test_sonic_vla_streaming.py
@@ -114,7 +114,11 @@ def test_robocasa_vla_camera_publisher_rate_limits_fake_sim(monkeypatch):
 
     class FakeEnv:
         def __init__(self):
-            self.sim = type("FakeSim", (), {"data": type("FakeData", (), {"_data": object()})()})()
+            self.sim = type(
+                "FakeSim",
+                (),
+                {"data": type("FakeData", (), {"_data": object()})()},
+            )()
 
     port = _free_port()
     publisher = RoboCasaVLACameraPublisher(
@@ -151,3 +155,117 @@ def test_robocasa_vla_camera_publisher_rate_limits_fake_sim(monkeypatch):
         publisher.close()
         sub.close()
         ctx.term()
+
+
+def test_robocasa_vla_camera_publisher_warms_cameras_during_start(monkeypatch):
+    class FakeRenderer:
+        def __init__(self):
+            self.cameras = []
+            self.render_count = 0
+
+        def update_scene(self, data, camera, scene_option=None):
+            self.cameras.append(camera)
+
+        def render(self):
+            self.render_count += 1
+            return np.zeros((12, 16, 3), dtype=np.uint8)
+
+    class FakeEnv:
+        def __init__(self):
+            self.sim = type(
+                "FakeSim",
+                (),
+                {"data": type("FakeData", (), {"_data": object()})()},
+            )()
+
+    camera_names = (
+        "robot0_head_camera",
+        "robot0_left_wrist_camera",
+        "robot0_right_wrist_camera",
+    )
+    publisher = RoboCasaVLACameraPublisher(
+        VLACameraConfig(
+            camera_names=camera_names,
+            output_keys=("ego_view", "left_wrist", "right_wrist"),
+            width=16,
+            height=12,
+            hz=30.0,
+        )
+    )
+    env = FakeEnv()
+    fake_renderer = FakeRenderer()
+
+    def fake_send_loop():
+        publisher._ready_event.set()
+        publisher._stop_event.wait(timeout=1.0)
+
+    monkeypatch.setattr(publisher, "_send_loop", fake_send_loop)
+    monkeypatch.setattr(
+        publisher,
+        "_get_live_renderer",
+        lambda env: (fake_renderer, None),
+    )
+
+    try:
+        publisher.start(env)
+
+        assert fake_renderer.cameras == list(camera_names)
+        assert fake_renderer.render_count == len(camera_names)
+    finally:
+        publisher.close()
+
+
+def test_robocasa_vla_camera_publisher_sends_multiple_camera_keys(monkeypatch):
+    class FakeRenderer:
+        def __init__(self):
+            self.cameras = []
+
+        def update_scene(self, data, camera, scene_option=None):
+            self.cameras.append(camera)
+
+        def render(self):
+            value = len(self.cameras)
+            return np.full((12, 16, 3), value, dtype=np.uint8)
+
+    class FakeEnv:
+        def __init__(self):
+            self.sim = type(
+                "FakeSim",
+                (),
+                {"data": type("FakeData", (), {"_data": object()})()},
+            )()
+
+    camera_names = (
+        "robot0_head_camera",
+        "robot0_left_wrist_camera",
+        "robot0_right_wrist_camera",
+    )
+    output_keys = ("ego_view", "left_wrist", "right_wrist")
+    publisher = RoboCasaVLACameraPublisher(
+        VLACameraConfig(
+            camera_names=camera_names,
+            output_keys=output_keys,
+            width=16,
+            height=12,
+            hz=30.0,
+        )
+    )
+    env = FakeEnv()
+    fake_renderer = FakeRenderer()
+    enqueued = []
+    monkeypatch.setattr(publisher, "_get_live_renderer", lambda env: (fake_renderer, None))
+    monkeypatch.setattr(
+        publisher,
+        "_enqueue_images",
+        lambda timestamps, images: enqueued.append((timestamps, images)),
+    )
+
+    assert publisher.maybe_publish(env)
+
+    timestamps, images = enqueued[0]
+    assert set(images) == set(output_keys)
+    assert set(timestamps) == set(output_keys)
+    assert fake_renderer.cameras == list(camera_names)
+    assert images["ego_view"].mean() == 1
+    assert images["left_wrist"].mean() == 2
+    assert images["right_wrist"].mean() == 3

--- a/tests/test_task_robot_init_offset_integration.py
+++ b/tests/test_task_robot_init_offset_integration.py
@@ -12,7 +12,10 @@ from robosuite.scripts.collect_sonic_g1_demos import SONIC_CFG
 from robocasa.utils import env_utils as EnvUtils
 
 
-def _make_env(task_name, layout_id=1):
+def _make_env(task_name, layout_id=1, mujoco_solver=None):
+    env_kwargs = {}
+    if mujoco_solver is not None:
+        env_kwargs["mujoco_solver"] = mujoco_solver
     return robosuite.make(
         task_name,
         robots=["SonicG1"],
@@ -29,6 +32,7 @@ def _make_env(task_name, layout_id=1):
         control_freq=200,
         initialization_noise=None,
         seed=7,
+        **env_kwargs,
     )
 
 
@@ -115,6 +119,42 @@ def test_close_dishwasher_writes_selected_side_pose_to_sonic_root():
             expected_anchor,
             atol=1e-7,
         )
+    finally:
+        if env is not None:
+            env.close()
+
+
+@pytest.mark.parametrize(
+    "task_name",
+    ["CloseDishwasher", "PickPlaceDrawerToCounter"],
+)
+def test_explicit_pgs_solver_survives_sonic_reset_and_step(task_name):
+    env = None
+    try:
+        env = _make_env(task_name, mujoco_solver="PGS")
+        env.reset()
+
+        assert env.sim.model._model.opt.solver == int(mujoco.mjtSolver.mjSOL_PGS)
+        env.step(np.zeros(env.action_spec[0].shape))
+        assert env.sim.model._model.opt.solver == int(mujoco.mjtSolver.mjSOL_PGS)
+        assert np.isfinite(env.sim.data.qpos).all()
+        assert np.isfinite(env.sim.data.qvel).all()
+        assert np.isfinite(env.sim.data.ctrl).all()
+
+        env.reset()
+        assert env.sim.model._model.opt.solver == int(mujoco.mjtSolver.mjSOL_PGS)
+    finally:
+        if env is not None:
+            env.close()
+
+
+def test_explicit_newton_solver_uses_mujoco_xml_spelling():
+    env = None
+    try:
+        env = _make_env("CloseDishwasher", mujoco_solver="newton")
+        env.reset()
+
+        assert env.sim.model._model.opt.solver == int(mujoco.mjtSolver.mjSOL_NEWTON)
     finally:
         if env is not None:
             env.close()

--- a/tests/test_task_robot_init_offset_integration.py
+++ b/tests/test_task_robot_init_offset_integration.py
@@ -45,18 +45,19 @@ def _xml_pelvis_position(env):
 
 
 @pytest.mark.parametrize(
-    ("task_name", "expected_offset"),
+    ("task_name", "expected_offset", "layout_id"),
     [
-        ("SlideDishwasherRack", (-0.50, 0.0)),
-        ("PickPlaceDrawerToCounter", (0.0, -0.35)),
+        ("SlideDishwasherRack", (-0.50, 0.0), 1),
+        ("PickPlaceDrawerToCounter", (0.0, -0.35), 1),
+        ("CloseFridgeDrawer", (0.0, -0.05), 4),
     ],
 )
 def test_tasks_apply_unified_offsets_before_the_sonic_root_is_written(
-    task_name, expected_offset
+    task_name, expected_offset, layout_id
 ):
     env = None
     try:
-        env = _make_env(task_name)
+        env = _make_env(task_name, layout_id=layout_id)
         env.reset()
         assert env.sim.model._model.opt.solver == int(mujoco.mjtSolver.mjSOL_NEWTON)
         unshifted_anchor, base_ori = EnvUtils.compute_robot_base_placement_pose(
@@ -79,6 +80,7 @@ def test_tasks_apply_unified_offsets_before_the_sonic_root_is_written(
             env.init_robot_base_pos_anchor,
             atol=1e-7,
         )
+        assert env.get_ep_meta()["robot_init_offset"] == list(expected_offset)
 
         env.step(np.zeros(env.action_spec[0].shape))
         assert np.isfinite(env.sim.data.qpos).all()

--- a/tests/test_task_robot_init_offset_integration.py
+++ b/tests/test_task_robot_init_offset_integration.py
@@ -1,0 +1,178 @@
+import xml.etree.ElementTree as ET
+
+import mujoco
+import numpy as np
+import pytest
+
+import robocasa  # noqa: F401  Registers RoboCasa environments with robosuite.
+import robosuite
+from robosuite.controllers import load_composite_controller_config
+from robosuite.scripts.collect_sonic_g1_demos import SONIC_CFG
+
+from robocasa.utils import env_utils as EnvUtils
+
+
+def _make_env(task_name, layout_id=1):
+    return robosuite.make(
+        task_name,
+        robots=["SonicG1"],
+        controller_configs=load_composite_controller_config(
+            controller=SONIC_CFG,
+            robot="SonicG1",
+        ),
+        has_renderer=False,
+        has_offscreen_renderer=False,
+        use_camera_obs=False,
+        ignore_done=True,
+        layout_ids=layout_id,
+        style_ids=1,
+        control_freq=200,
+        initialization_noise=None,
+        seed=7,
+    )
+
+
+def _xml_pelvis_position(env):
+    root = ET.fromstring(env.model.get_xml())
+    pelvis = next(
+        body for body in root.iter("body") if body.get("name") == "robot0_pelvis"
+    )
+    return np.fromstring(pelvis.attrib["pos"], sep=" ")
+
+
+@pytest.mark.parametrize(
+    ("task_name", "expected_offset"),
+    [
+        ("SlideDishwasherRack", (-0.50, 0.0)),
+        ("PickPlaceDrawerToCounter", (0.0, -0.35)),
+    ],
+)
+def test_tasks_apply_unified_offsets_before_the_sonic_root_is_written(
+    task_name, expected_offset
+):
+    env = None
+    try:
+        env = _make_env(task_name)
+        env.reset()
+        assert env.sim.model._model.opt.solver == int(mujoco.mjtSolver.mjSOL_NEWTON)
+        unshifted_anchor, base_ori = EnvUtils.compute_robot_base_placement_pose(
+            env,
+            ref_fixture=env.get_fixture(env.init_robot_base_ref),
+        )
+        expected_anchor = EnvUtils.apply_robot_init_offset(
+            unshifted_anchor,
+            base_ori,
+            expected_offset,
+        )
+
+        np.testing.assert_allclose(
+            env.init_robot_base_pos_anchor,
+            expected_anchor,
+            atol=1e-7,
+        )
+        np.testing.assert_allclose(
+            _xml_pelvis_position(env),
+            env.init_robot_base_pos_anchor,
+            atol=1e-7,
+        )
+
+        env.step(np.zeros(env.action_spec[0].shape))
+        assert np.isfinite(env.sim.data.qpos).all()
+        assert np.isfinite(env.sim.data.qvel).all()
+        assert np.isfinite(env.sim.data.ctrl).all()
+    finally:
+        if env is not None:
+            env.close()
+
+
+def test_close_dishwasher_writes_selected_side_pose_to_sonic_root():
+    env = None
+    try:
+        env = _make_env("CloseDishwasher")
+        env.reset()
+
+        lateral_offset = env.fxtr.width / 2 + env.X_OFS
+        if env.drawer_side == "right":
+            lateral_offset *= -1
+        expected_anchor, expected_ori = EnvUtils.compute_robot_base_placement_pose(
+            env,
+            ref_fixture=env.fxtr,
+            offset=(lateral_offset, env.Y_OFS),
+        )
+
+        np.testing.assert_allclose(
+            env.init_robot_base_pos_anchor,
+            expected_anchor,
+            atol=1e-7,
+        )
+        np.testing.assert_allclose(
+            env.init_robot_base_ori_anchor,
+            expected_ori,
+            atol=1e-7,
+        )
+        np.testing.assert_allclose(
+            _xml_pelvis_position(env),
+            expected_anchor,
+            atol=1e-7,
+        )
+    finally:
+        if env is not None:
+            env.close()
+
+
+@pytest.mark.parametrize(
+    ("task_name", "layout_id"),
+    [
+        ("OpenDishwasher", 1),
+        ("OpenOven", 2),
+        ("CloseOven", 2),
+    ],
+)
+def test_lower_door_tasks_write_selected_pose_to_sonic_root(task_name, layout_id):
+    env = None
+    try:
+        env = _make_env(task_name, layout_id=layout_id)
+        env.reset()
+
+        np.testing.assert_allclose(
+            _xml_pelvis_position(env),
+            env.init_robot_base_pos_anchor,
+            atol=1e-7,
+        )
+        env.step(np.zeros(env.action_spec[0].shape))
+        assert np.isfinite(env.sim.data.qpos).all()
+        assert np.isfinite(env.sim.data.qvel).all()
+    finally:
+        if env is not None:
+            env.close()
+
+
+def test_episode_metadata_restores_the_task_offset_after_the_registry_changes(
+    monkeypatch,
+):
+    source = restored = None
+    try:
+        source = _make_env("PickPlaceDrawerToCounter")
+        source.reset()
+        metadata = source.get_ep_meta()
+        monkeypatch.setitem(
+            EnvUtils._TASK_ROBOT_INIT_OFFSETS,
+            "PickPlaceDrawerToCounter",
+            (0.0, 0.0),
+        )
+        assert metadata["robot_init_offset"] == [0.0, -0.35]
+
+        restored = _make_env("PickPlaceDrawerToCounter")
+        restored.set_ep_meta(metadata)
+        restored.reset()
+
+        np.testing.assert_allclose(
+            restored.init_robot_base_pos_anchor,
+            source.init_robot_base_pos_anchor,
+            atol=1e-7,
+        )
+    finally:
+        if source is not None:
+            source.close()
+        if restored is not None:
+            restored.close()

--- a/tests/test_task_robot_init_offsets.py
+++ b/tests/test_task_robot_init_offsets.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from robocasa.utils import env_utils as EnvUtils
+
+
+@pytest.mark.parametrize(
+    ("task_name", "expected_offset"),
+    [
+        ("SlideDishwasherRack", (-0.50, 0.0)),
+        ("PickPlaceDrawerToCounter", (0.0, -0.35)),
+        ("OpenDrawer", (0.0, 0.0)),
+    ],
+)
+def test_task_robot_init_offsets_use_two_task_overrides_and_a_zero_default(
+    task_name, expected_offset
+):
+    assert EnvUtils.get_task_robot_init_offset(task_name) == expected_offset
+
+
+def test_task_robot_offsets_apply_only_to_sonic_g1():
+    class SonicG1:
+        pass
+
+    class PandaOmron:
+        pass
+
+    task_offset = (-0.50, 0.0)
+    sonic_env = SimpleNamespace(
+        robots=[SimpleNamespace(robot_model=SonicG1())],
+        robot_init_offset=task_offset,
+    )
+    panda_env = SimpleNamespace(
+        robots=[SimpleNamespace(robot_model=PandaOmron())],
+        robot_init_offset=task_offset,
+    )
+
+    assert EnvUtils.get_effective_robot_init_offset(sonic_env) == task_offset
+    assert EnvUtils.get_effective_robot_init_offset(panda_env) == (0.0, 0.0)
+
+
+@pytest.mark.parametrize(
+    ("yaw", "offset"),
+    [
+        (0.0, (-0.50, 0.0)),
+        (np.pi / 2, (-0.50, 0.0)),
+        (np.pi, (0.0, -0.35)),
+        (-np.pi / 2, (0.0, -0.35)),
+    ],
+)
+def test_apply_robot_init_offset_uses_robot_local_lateral_and_longitudinal_axes(
+    yaw, offset
+):
+    position = np.array([1.0, -2.0, 0.793])
+    orientation = np.array([0.0, 0.0, yaw])
+    lateral, longitudinal = offset
+    expected = position + np.array(
+        [
+            np.sin(yaw) * lateral + np.cos(yaw) * longitudinal,
+            -np.cos(yaw) * lateral + np.sin(yaw) * longitudinal,
+            0.0,
+        ]
+    )
+
+    np.testing.assert_allclose(
+        EnvUtils.apply_robot_init_offset(position, orientation, offset),
+        expected,
+        atol=1e-12,
+    )

--- a/tests/test_task_robot_init_offsets.py
+++ b/tests/test_task_robot_init_offsets.py
@@ -11,10 +11,12 @@ from robocasa.utils import env_utils as EnvUtils
     [
         ("SlideDishwasherRack", (-0.50, 0.0)),
         ("PickPlaceDrawerToCounter", (0.0, -0.35)),
+        ("CloseFridgeDrawer", (0.0, -0.05)),
+        ("OpenFridgeDrawer", (0.0, 0.0)),
         ("OpenDrawer", (0.0, 0.0)),
     ],
 )
-def test_task_robot_init_offsets_use_two_task_overrides_and_a_zero_default(
+def test_task_robot_init_offsets_use_task_overrides_and_a_zero_default(
     task_name, expected_offset
 ):
     assert EnvUtils.get_task_robot_init_offset(task_name) == expected_offset


### PR DESCRIPTION
## Summary

- publish synchronized head, left-wrist, and right-wrist camera streams from the RoboCasa collector
- improve episode synchronization and reset metadata lifecycle across raw HDF5 and LeRobot collection
- improve SonicG1 task initialization, placement compatibility, and success checks
- replace `PortionHotDogs` with `PortionPeaches` and add `DrawerCakeSort` with regression coverage
- use PGS for SONIC collection and default to randomized compatible test layouts

## Motivation

This is an incremental follow-up to #208 and intentionally targets its `codex/robocasa-sonic-vla-streaming` branch. The changes make repeated SONIC G1 collection safer while keeping raw HDF5 episodes and three-camera LeRobot exports synchronized.

## Key fixes

- carry all three camera images in each synchronized collector message
- clear serialized episode metadata before every fresh reset
- write final task-specific SonicG1 base placement into the robot XML before MuJoCo compilation
- constrain inaccessible object placements while preserving behavior for other robots
- synchronize episode boundaries and instructions between RoboCasa and the exporter
- keep Numba cache artifacts outside editable RoboSuite checkouts
- default manual SONIC collection to layout `-1` for compatible randomized test layouts

## Validation

Latest update:

- `NUMBA_DISABLE_JIT=1 /home/user/miniforge3/envs/robocasa/bin/python -m pytest -q tests/test_collect_sonic_render_camera.py` — 4 passed
- `git diff --check upstream/codex/robocasa-sonic-vla-streaming...HEAD`

Earlier commits in this PR were also validated with 44 focused streaming, reset, task-placement, and sampler tests; Python compile checks; Black; repeated task reset/step checks; and a real three-camera EGL publish benchmark below the 5 ms control period.