### PR TITLE
tests: repair three scripts that fail before they can run

### DIFF
--- a/tests/test_dataset_playback.py
+++ b/tests/test_dataset_playback.py
@@ -54,8 +54,26 @@ class TestTasksValidity(unittest.TestCase):
             args.first = False
             args.extend_states = False
             args.verbose = False
+            args.camera_height = 512
+            args.camera_width = 768
 
-            playback_dataset(args)
+            playback_dataset(
+                dataset=args.dataset,
+                use_actions=args.use_actions,
+                use_abs_actions=args.use_abs_actions,
+                use_obs=args.use_obs,
+                filter_key=args.filter_key,
+                n=args.n,
+                render=args.render,
+                render_image_names=args.render_image_names,
+                camera_height=args.camera_height,
+                camera_width=args.camera_width,
+                video_path=args.video_path,
+                video_skip=args.video_skip,
+                extend_states=args.extend_states,
+                first=args.first,
+                verbose=args.verbose,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_door_fixtures.py
+++ b/tests/test_door_fixtures.py
@@ -31,7 +31,7 @@ SKIP_FXTRS = ["handle_knob"]
 
 def get_all_style_configs():
     style_config_list = []
-    for i in range(12):
+    for i in range(1, 61):
         style_path = get_style_path(style_id=i)
         with open(style_path, "r") as f:
             style_config = yaml.safe_load(f)

--- a/tests/test_env_determinism.py
+++ b/tests/test_env_determinism.py
@@ -7,7 +7,7 @@ from lxml import etree as ET
 import mujoco
 import robocasa
 import robosuite
-from robosuite import load_controller_config
+from robosuite.controllers import load_composite_controller_config
 from termcolor import colored
 
 DEFAULT_SEED = 3
@@ -99,8 +99,8 @@ class TestEnvDeterminism(unittest.TestCase):
             config = {
                 "env_name": env,
                 "robots": "PandaOmron",
-                "controller_configs": load_controller_config(
-                    default_controller="OSC_POSE"
+                "controller_configs": load_composite_controller_config(
+                    controller=None, robot="PandaOmron"
                 ),
                 "has_renderer": False,
                 "has_offscreen_renderer": False,
@@ -131,9 +131,11 @@ class TestEnvDeterminism(unittest.TestCase):
         """
 
         config = {
-            "env_name": "PnPCounterToCab",
+            "env_name": "PickPlaceCounterToCabinet",
             "robots": "PandaOmron",
-            "controller_configs": load_controller_config(default_controller="OSC_POSE"),
+            "controller_configs": load_composite_controller_config(
+                controller=None, robot="PandaOmron"
+            ),
             "has_renderer": False,
             "has_offscreen_renderer": False,
             "ignore_done": True,
@@ -162,9 +164,11 @@ class TestEnvDeterminism(unittest.TestCase):
         """
 
         config = {
-            "env_name": "PnPCounterToCab",
+            "env_name": "PickPlaceCounterToCabinet",
             "robots": "PandaOmron",
-            "controller_configs": load_controller_config(default_controller="OSC_POSE"),
+            "controller_configs": load_composite_controller_config(
+                controller=None, robot="PandaOmron"
+            ),
             "has_renderer": False,
             "has_offscreen_renderer": False,
             "ignore_done": True,


### PR DESCRIPTION
Hi — while smoke-testing a fresh clone I found three scripts under `tests/` that fail before they can do any work. Each has a determinate fix, so I've grouped them here; the findings that need a decision from you are in #220 instead.

**Environment:** `main` at `a07e365`, robosuite `1.5.2` (master, `5ce6643`), mujoco `3.3.1`, numpy `2.2.5`, gymnasium `0.29.1`, Python 3.11, Linux, headless (`MUJOCO_GL=egl`).

### `test_env_determinism.py` — `ImportError` at module load

`from robosuite import load_controller_config` no longer resolves on robosuite 1.5.2, so the module raises before any test runs. Switched to `load_composite_controller_config(controller=None, robot="PandaOmron")`, the same helper `robocasa/utils/env_utils.py:81` uses.

The literal port would have been `load_part_controller_config(default_controller="OSC_POSE")`, but the composite call matches how the rest of the codebase builds this robot and is equivalent here: the arm entry of the PandaOmron composite default is the same `OSC_POSE` config (same `kp`, `output_max`, `input_type`, `input_ref_frame`) with a `gripper` entry added, and the composite adds the `torso`/`base` controllers a mobile robot needs. The test never steps — `create_env` only calls `env.reset()`, and the assertions compare layout, style and placements — so the controller choice doesn't affect the outcome either way.

The two hardcoded `PnPCounterToCab` names go to `PickPlaceCounterToCabinet` in the same pass, since that name is no longer registered either.

*Verified:* the module imports, and `test_random_generative_textures` and `test_randomized_cameras` both pass (`Ran 2 tests ... OK`). `test_env_determinism` itself then fails on the first environment for a separate reason — it's described in #220, since fixing it means touching `robocasa/models/fixtures/counter.py` rather than the tests.

### `test_door_fixtures.py` — `KeyError: 0` before any environment is built

`get_all_style_configs()` iterates `range(12)`, and `get_style_path(style_id=0)` raises `KeyError: 0` because `StyleType` has no `0` — its concrete values run 1–60 (the only negative member is `ALL = -3`). The `range(12)` bound looks like it predates the v1.0 style set. Changed to `range(1, 61)`, matching the identically-named helper in `tests/test_fixtures.py:31`.

Worth flagging since it changes the runtime: the script now sweeps all 60 styles where the old loop was written for 12, so it takes correspondingly longer. If you'd rather keep the original scope, `range(1, 12)` fixes the off-by-one without widening the sweep — say which you'd prefer and I'll amend.

*Verified:* `python tests/test_door_fixtures.py --cabinet_panel slab --layout 1` no longer raises `KeyError`, and now builds all four environments (`OpenCabinet`, `CloseCabinet`, `OpenDrawer`, `CloseDrawer`) before hitting the `run_random_rollouts` assertion described in #220.

### `test_dataset_playback.py` — `TypeError` on the `playback_dataset` call

`playback_dataset()` takes 15 explicit parameters, but the test passes a single namespace:

```text
TypeError: playback_dataset() missing 14 required positional arguments: 'use_actions', 'use_abs_actions', 'use_obs', 'filter_key', 'n', 'render', 'render_image_names', 'camera_height', 'camera_width', 'video_path', 'video_skip', 'extend_states', 'first', and 'verbose'
```

Now called by keyword, matching the existing call sites in `robocasa/scripts/dataset_scripts/playback_dataset.py:490` and `robocasa/demos/demo_tasks.py:180`. `camera_height`/`camera_width` weren't set on the namespace at all, so I added them with the CLI defaults (512/768).

*Partially verified:* the `TypeError` is gone. I don't have the datasets downloaded, and the run now stops earlier for a separate reason — the task and split selection at `tests/test_dataset_playback.py:25-27`, described in #220 — so I have never seen this test complete a playback. Please treat it as untested end to end. If you'd rather this hunk landed once, together with the selection fix, I'm happy to drop it from this PR.

### Deliberately not included

The v0.2 task names and layout ids in `test_layouts.py`, `test_fixtures.py` and `test_env_speed.py`, `test_env_speed.py`'s hardcoded `onscreen=True`, the same dead `load_controller_config` import in `robocasa/utils/eval_utils.py:5`, and the two global-RNG calls in `robocasa/models/fixtures/counter.py`. Each of those could reasonably be fixed or deleted, and that's your call rather than mine — all four are in #220 with details.

`pre-commit run --files ...` (black 22.10.0) passes on all three files.
